### PR TITLE
Fix sign in with Apple cell background color

### DIFF
--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/SignInWithAppleButtonTableViewCell.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/SignInWithAppleButtonTableViewCell.swift
@@ -31,6 +31,9 @@ final class SignInWithAppleButtonTableViewCell: UITableViewCell {
         self.loginButton.addTarget(self, action: #selector(self.didTapSignIn(_:)), for: .touchUpInside)
         self.loginButton.translatesAutoresizingMaskIntoConstraints = false
         
+        self.backgroundColor = .secondarySystemBackground
+        self.contentView.backgroundColor = .secondarySystemBackground
+        
         self.contentView.addSubview(self.loginButton)
     }
     


### PR DESCRIPTION
Small PR adding same background colour `MobileWorkflowButtonTableViewCell` is using to `SignInWithAppleButtonTableViewCell`.