### PR TITLE
ROPC auth

### DIFF
--- a/MWAppAuthPlugin/MWAppAuthPlugin.xcodeproj/project.pbxproj
+++ b/MWAppAuthPlugin/MWAppAuthPlugin.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		36277DB625EEA839008AA190 /* MWAppAuthStepViewController+Apple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36277DB525EEA839008AA190 /* MWAppAuthStepViewController+Apple.swift */; };
+		36277DCE25EEA908008AA190 /* MWAppAuthStepViewController+AppAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36277DCD25EEA908008AA190 /* MWAppAuthStepViewController+AppAuth.swift */; };
+		36277DD425EEAABF008AA190 /* MWAppAuthStepViewController+ROPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36277DD325EEAABF008AA190 /* MWAppAuthStepViewController+ROPC.swift */; };
 		36542B3325A887E6001CECE6 /* AuthItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36542B3225A887E6001CECE6 /* AuthItem.swift */; };
 		36C18355256E9D5D0044A74B /* MWAppAuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36C18354256E9D5D0044A74B /* MWAppAuthPlugin.swift */; };
 		36E88C9A2538965600BC6A98 /* MWAppAuthPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36E88C902538965500BC6A98 /* MWAppAuthPlugin.framework */; };
@@ -32,6 +35,9 @@
 /* Begin PBXFileReference section */
 		02BAD96F111AAA0652780E40 /* Pods-MWAppAuthPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MWAppAuthPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-MWAppAuthPluginTests/Pods-MWAppAuthPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		0F7349BC690012EC1F9F3F7E /* Pods-MWAppAuth-MobileWorkflowAppAuthPlugin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MWAppAuth-MobileWorkflowAppAuthPlugin.debug.xcconfig"; path = "Target Support Files/Pods-MWAppAuth-MobileWorkflowAppAuthPlugin/Pods-MWAppAuth-MobileWorkflowAppAuthPlugin.debug.xcconfig"; sourceTree = "<group>"; };
+		36277DB525EEA839008AA190 /* MWAppAuthStepViewController+Apple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MWAppAuthStepViewController+Apple.swift"; sourceTree = "<group>"; };
+		36277DCD25EEA908008AA190 /* MWAppAuthStepViewController+AppAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MWAppAuthStepViewController+AppAuth.swift"; sourceTree = "<group>"; };
+		36277DD325EEAABF008AA190 /* MWAppAuthStepViewController+ROPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MWAppAuthStepViewController+ROPC.swift"; sourceTree = "<group>"; };
 		36542B3225A887E6001CECE6 /* AuthItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthItem.swift; sourceTree = "<group>"; };
 		36C18354256E9D5D0044A74B /* MWAppAuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MWAppAuthPlugin.swift; sourceTree = "<group>"; };
 		36E88C902538965500BC6A98 /* MWAppAuthPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MWAppAuthPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,6 +125,9 @@
 				36C18354256E9D5D0044A74B /* MWAppAuthPlugin.swift */,
 				36E88CDD2538AA8B00BC6A98 /* MWAppAuthStep.swift */,
 				36E88CDE2538AA8B00BC6A98 /* MWAppAuthStepViewController.swift */,
+				36277DB525EEA839008AA190 /* MWAppAuthStepViewController+Apple.swift */,
+				36277DCD25EEA908008AA190 /* MWAppAuthStepViewController+AppAuth.swift */,
+				36277DD325EEAABF008AA190 /* MWAppAuthStepViewController+ROPC.swift */,
 				36542B3225A887E6001CECE6 /* AuthItem.swift */,
 				ADBC77B325D148C5000AB52F /* SignInWithAppleButtonTableViewCell.swift */,
 			);
@@ -310,9 +319,12 @@
 			files = (
 				36E88CE02538AA8B00BC6A98 /* MWAppAuthStepViewController.swift in Sources */,
 				36C18355256E9D5D0044A74B /* MWAppAuthPlugin.swift in Sources */,
+				36277DD425EEAABF008AA190 /* MWAppAuthStepViewController+ROPC.swift in Sources */,
 				ADBC77B525D148C5000AB52F /* SignInWithAppleButtonTableViewCell.swift in Sources */,
 				36542B3325A887E6001CECE6 /* AuthItem.swift in Sources */,
+				36277DCE25EEA908008AA190 /* MWAppAuthStepViewController+AppAuth.swift in Sources */,
 				36E88CDF2538AA8B00BC6A98 /* MWAppAuthStep.swift in Sources */,
+				36277DB625EEA839008AA190 /* MWAppAuthStepViewController+Apple.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/AuthItem.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/AuthItem.swift
@@ -142,10 +142,9 @@ struct OAuth2Config {
 }
 
 struct OAuthROPCConfig {
-    let oAuth2Url: String
+    let oAuth2TokenUrl: String
     let oAuth2ClientId: String
     let oAuth2ClientSecret: String?
-    let oAuth2TokenUrl: String?
 }
 
 enum AuthItemRepresentation {
@@ -176,10 +175,10 @@ extension AuthItem {
             }
             return .oauth(buttonTitle: self.buttonTitle, config: OAuth2Config(oAuth2Url: oAuth2Url, oAuth2ClientId: oAuth2ClientId, oAuth2ClientSecret: self.oAuth2ClientSecret, oAuth2Scope: oAuth2Scope, oAuth2RedirectScheme: oAuth2RedirectScheme))
         case .oauthRopc:
-            guard let oAuth2Url = self.oAuth2Url, let oAuth2ClientId = self.oAuth2ClientId else {
+            guard let oAuth2TokenUrl = self.oAuth2TokenUrl, let oAuth2ClientId = self.oAuth2ClientId else {
                 throw ParseError.invalidStepData(cause: "Missing required OAuth2 parameters")
             }
-            return .oauthRopc(buttonTitle: self.buttonTitle, config: OAuthROPCConfig(oAuth2Url: oAuth2Url, oAuth2ClientId: oAuth2ClientId, oAuth2ClientSecret: self.oAuth2ClientSecret, oAuth2TokenUrl: self.oAuth2TokenUrl))
+            return .oauthRopc(buttonTitle: self.buttonTitle, config: OAuthROPCConfig(oAuth2TokenUrl: oAuth2TokenUrl, oAuth2ClientId: oAuth2ClientId, oAuth2ClientSecret: self.oAuth2ClientSecret))
         case .twitter:
             return .twitter(buttonTitle: self.buttonTitle)
         case .modalWorkflow:

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -121,6 +121,11 @@ class MWAppAuthStep: ORKTableStep, UITableViewDelegate {
                 preconditionFailure()
             }
             buttonCell.configureButton(label: buttonTitle, style: .primary)
+        case .oauthRopc(let buttonTitle, _):
+            guard let buttonCell = cell as? MobileWorkflowButtonTableViewCell else {
+                preconditionFailure()
+            }
+            buttonCell.configureButton(label: buttonTitle, style: .primary)
         case .twitter(let buttonTitle):
             guard let buttonCell = cell as? MobileWorkflowButtonTableViewCell else {
                 preconditionFailure()
@@ -175,6 +180,7 @@ extension MWAppAuthStep: MobileWorkflowStep {
             let oAuth2ClientSecret = content["oAuth2ClientSecret"] as? String
             let oAuth2Scope = content["oAuth2Scope"] as? String
             let oAuth2RedirectScheme = content["oAuth2RedirectScheme"] as? String
+            let oAuth2TokenUrl = content["oAuth2TokenUrl"] as? String
             
             let modalWorkflowId: Int?
             if let id = content["modalWorkflowId"] as? String, id.isEmpty == false {
@@ -195,6 +201,7 @@ extension MWAppAuthStep: MobileWorkflowStep {
                 oAuth2ClientSecret: oAuth2ClientSecret,
                 oAuth2Scope: oAuth2Scope,
                 oAuth2RedirectScheme: oAuth2RedirectScheme,
+                oAuth2TokenUrl: oAuth2TokenUrl,
                 modalWorkflowId: modalWorkflowId,
                 appleFullNameScope: appleFullNameScope,
                 appleEmailScope: appleEmailScope,

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -18,6 +18,9 @@ enum L10n {
         static func unsupportedItemTypeError(type: String) -> String {
             "Unsupported item type: \(type)"
         }
+        static let loginDetailsTitle = "Please enter your login details:"
+        static let usernameFieldTitle = "Username"
+        static let passwordFieldTitle = "Password"
     }
     
     enum AppleLogin {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+AppAuth.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+AppAuth.swift
@@ -1,0 +1,98 @@
+//
+//  MWAppAuthStepViewController+AppAuth.swift
+//  MWAppAuthPlugin
+//
+//  Created by Jonathan Flintham on 02/03/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+import AppAuth
+import AuthenticationServices
+
+extension MWAppAuthStepViewController {
+    
+    func performOAuth(config: OAuth2Config) {
+        guard
+            let oAuth2Url = self.appAuthStep.session.resolve(url: config.oAuth2Url)?.absoluteString,
+            let authorizationEndpoint = URL(string: oAuth2Url.appending(OAuthPaths.authorization)),
+            let tokenEndpoint = URL(string: oAuth2Url.appending(OAuthPaths.token)),
+            let redirectURL = URL(string: config.oAuth2RedirectScheme + "://callback")
+            else { return }
+        
+        self.showLoading()
+        
+        let configuration = OIDServiceConfiguration(
+            authorizationEndpoint: authorizationEndpoint,
+            tokenEndpoint: tokenEndpoint
+        )
+        
+        let request = OIDAuthorizationRequest(
+            configuration: configuration,
+            clientId: config.oAuth2ClientId,
+            clientSecret: (config.oAuth2ClientSecret?.isEmpty ?? true) ? nil : config.oAuth2ClientSecret,
+            scopes: [config.oAuth2Scope],
+            redirectURL: redirectURL,
+            responseType: OIDResponseTypeCode,
+            additionalParameters: nil
+        )
+        
+        let authProvider = AuthProviderImplementation() { completion in
+            let session = OIDAuthState.authState(byPresenting: request, presenting: self) { authState, error in
+                if let authState = authState, let accessToken = authState.lastTokenResponse?.accessToken, let  expirationDate = authState.lastTokenResponse?.accessTokenExpirationDate {
+                    let token = Credential(
+                        type: CredentialType.token.rawValue,
+                        value: accessToken,
+                        expirationDate: expirationDate
+                    )
+                    completion(.success(token))
+                } else {
+                    completion(.failure(error ?? CredentialError.unexpected))
+                }
+            }
+            return AppAuthFlowResumer(session: session)
+        }
+        let authenticationTask = AuthenticationTask(input: authProvider)
+        self.appAuthStep?.services.perform(task: authenticationTask, session: self.appAuthStep.session) { [weak self] (response) in
+            DispatchQueue.main.async {
+                self?.hideLoading()
+                switch response {
+                case .success:
+                    self?.goForward()
+                case .failure(let error):
+                    if let authError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? ASWebAuthenticationSessionError, authError.code == .canceledLogin {
+                        // if cancel, do nothing
+                    } else {
+                        self?.show(error)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Authorization Controller Presentation
+
+extension MWAppAuthStepViewController: ASAuthorizationControllerPresentationContextProviding {
+    
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let windows = self.view.window else {
+            preconditionFailure()
+        }
+        
+        return windows
+    }
+}
+
+class AppAuthFlowResumer: AuthFlowResumer {
+    
+    private var session: OIDExternalUserAgentSession?
+    
+    init(session: OIDExternalUserAgentSession) {
+        self.session = session
+    }
+    
+    func resumeAuth(with url: URL) -> Bool {
+        return self.session?.resumeExternalUserAgentFlow(with: url) ?? false
+    }
+}

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+Apple.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+Apple.swift
@@ -1,0 +1,170 @@
+//
+//  MWAppAuthStepViewController+Apple.swift
+//  MWAppAuthPlugin
+//
+//  Created by Jonathan Flintham on 02/03/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+import AuthenticationServices
+
+// MARK: - Sign in with Apple
+
+extension MWAppAuthStepViewController: SignInWithAppleButtonTableViewCellDelegate {
+    func appleCell(_ cell: SignInWithAppleButtonTableViewCell, didTapButton button: UIButton) {
+        guard let indexPath = self.tableView?.indexPath(for: cell), let item = self.appAuthStep.objectForRow(at: indexPath) as? AuthItem, let representation = try? item.respresentation() else { return }
+        
+        switch representation {
+        case .apple:
+            self.appleAccessTokenURL = item.appleAccessTokenURL
+            self.handleDidTapSignInWithApple(needsFullName: item.appleFullNameScope ?? false, needsEmail: item.appleEmailScope ?? false)
+        default:
+            break
+        }
+    }
+}
+
+extension MWAppAuthStepViewController {
+    
+    func handleDidTapSignInWithApple(needsFullName: Bool, needsEmail: Bool) {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = []
+        
+        if needsFullName {
+            request.requestedScopes?.append(.fullName)
+        }
+        
+        if needsEmail {
+            request.requestedScopes?.append(.email)
+        }
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        
+        authorizationController.performRequests()
+    }
+    
+    func performSignInWithApple(userId: String, name: String, identityToken: String) {
+        
+        let appleCredential = AppleIDCredential(userId: userId, name: name, identityToken: identityToken)
+        
+        guard let urlString = self.appleAccessTokenURL,
+              let url = self.appAuthStep.session.resolve(url: urlString)
+        else {
+            return
+        }
+        
+        let data = try? JSONEncoder().encode(appleCredential)
+        
+        let parser: (Data) throws -> Credential = { data in
+            return try JSONDecoder().decode(Credential.self, from: data)
+        }
+        
+        let authTask = URLAsyncTask<Credential>.build(url: url, method: .POST, body: data, session: self.appAuthStep.session, parser: parser)
+        
+        self.appAuthStep?.services.perform(task: authTask, session: self.appAuthStep.session) { [weak self] (response) in
+            DispatchQueue.main.async {
+                self?.hideLoading()
+                switch response {
+                case .success(let credential):
+                    self?.appAuthStep.services.credentialStore.updateCredential(credential, completion: { result in
+                        switch result {
+                        case .success:
+                            self?.goForward()
+                        case .failure(let error):
+                            self?.show(error)
+                        }
+                    })
+                case .failure(let error):
+                    self?.show(error)
+                }
+            }
+        }
+    }
+    
+    func makeName(fullName: PersonNameComponents?) -> String {
+        guard let fullName = fullName else {
+            return ""
+        }
+        
+        var nameComponents = [String]()
+        if let givenName = fullName.givenName {
+            nameComponents.append(givenName)
+        }
+        if let familyName = fullName.familyName {
+            nameComponents.append(familyName)
+        }
+        
+        if nameComponents.isEmpty {
+            return self.appleUsername ?? ""
+        } else {
+            let name = nameComponents.joined(separator: " ")
+            self.appleUsername = name
+            
+            return name
+        }
+    }
+}
+
+struct AppleIDCredential: Codable {
+    let userId: String
+    let name: String
+    let identityToken: String
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_identity"
+        case name = "name"
+        case identityToken = "jwt"
+    }
+}
+
+// MARK: - Authorization Controller Delegate
+
+extension MWAppAuthStepViewController: ASAuthorizationControllerDelegate {
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        
+        switch authorization.credential {
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            
+            // Name is only provided in the first response of an Auth request. Save it in case multiple attempts are required
+            let name = self.makeName(fullName: appleIDCredential.fullName)
+            
+            guard let identityToken = appleIDCredential.identityToken, let identityTokenString = String(data: identityToken, encoding: .utf8) else {
+                self.showConfirmationAlert(title: L10n.AppleLogin.errorTitle, message: L10n.AppleLogin.errorMessage) { _ in }
+                return
+            }
+            
+            // Expiration date is not currently used, hence credential was set to `.distantFuture`. This should be reviewed in the future.
+            let userIdCredential = Credential(
+                type: CredentialType.appleIdCredentialUser.rawValue,
+                value: appleIDCredential.user,
+                expirationDate: .distantFuture
+            )
+
+            self.appAuthStep.services.credentialStore.updateCredential(userIdCredential) { [weak self] result in
+                switch result {
+                case .success:
+                    self?.performSignInWithApple(userId: appleIDCredential.user, name: name, identityToken: identityTokenString)
+                    
+                case .failure(let error):
+                    self?.show(error)
+                }
+            }
+            
+        default:
+            break
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        guard let authError = error as? ASAuthorizationError, authError.code != .canceled else {
+            return
+        }
+        
+        self.showConfirmationAlert(title: L10n.AppleLogin.errorTitle, message: L10n.AppleLogin.errorMessage) { _ in }
+    }
+}

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -28,7 +28,7 @@ fileprivate class ROPCFormTaskViewController: ORKTaskViewController {
 
 extension MWAppAuthStepViewController {
     
-    func performOAuthROPC(config: OAuthROPCConfig) {
+    func performOAuthROPC(title: String, config: OAuthROPCConfig) {
         
         let headerTitleItem = ORKFormItem(sectionTitle: L10n.AppAuth.loginDetailsTitle)
         
@@ -47,7 +47,7 @@ extension MWAppAuthStepViewController {
         let passwordFormItem = ORKFormItem(identifier: kPasswordItemIdentifier, text: L10n.AppAuth.passwordFieldTitle, answerFormat: passwordAnswerFormat)
         passwordFormItem.isOptional = false
         
-        let step = ORKFormStep(identifier: kFormStepIdentifier, title: L10n.AppAuth.loginTitle, text: nil)
+        let step = ORKFormStep(identifier: kFormStepIdentifier, title: title.capitalized, text: nil)
         step.formItems = [headerTitleItem, usernameFormItem, passwordFormItem]
         step.isOptional = false
         
@@ -129,6 +129,10 @@ struct ROPCResponse: Decodable {
 }
 
 extension MWAppAuthStepViewController: ORKTaskViewControllerDelegate {
+    
+    func taskViewController(_ taskViewController: ORKTaskViewController, stepViewControllerWillAppear stepViewController: ORKStepViewController) {
+        stepViewController.continueButtonTitle = L10n.AppAuth.loginTitle
+    }
     
     func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
         taskViewController.presentingViewController?.dismiss(animated: true) { [weak self] in

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -1,0 +1,78 @@
+//
+//  MWAppAuthStepViewController+ROPC.swift
+//  MWAppAuthPlugin
+//
+//  Created by Jonathan Flintham on 02/03/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+
+extension MWAppAuthStepViewController {
+    
+    func performOAuthROPC(config: OAuthROPCConfig) {
+        guard
+            let tokenUrlString = config.oAuth2TokenUrl,
+            let tokenURL = self.appAuthStep.session.resolve(url: tokenUrlString)
+        else { return }
+        
+        var params: [String: String] = [
+            "grant_type": "password",
+            "client_id": config.oAuth2ClientId,
+            "username": "***",
+            "password": "***"
+        ]
+        if let secret = config.oAuth2ClientSecret {
+            params["client_secret"] = config.oAuth2ClientSecret
+        }
+        
+        let paramsString = params.map({ "\($0.key)=\($0.value)" }).joined(separator: "&") // url encoding
+        
+        let task = URLAsyncTask<ROPCResponse>.build(
+            url: tokenURL,
+            method: .POST,
+            body: paramsString.data(using: .utf8),
+            session: self.appAuthStep.session,
+            headers: ["Content-Type": "application/x-www-form-urlencoded"],
+            parser: { try ROPCResponse.parse(data: $0) }
+        )
+        
+        self.ropcNetworkService.perform(task: task, session: self.appAuthStep.session, respondOn: DispatchQueue.main) { [weak self] result in
+            switch result {
+            case .success(let response):
+                let credential = Credential(
+                    type: CredentialType.token.rawValue,
+                    value: response.accessToken,
+                    expirationDate: Date().addingTimeInterval(TimeInterval(response.expiresIn))
+                )
+                self?.appAuthStep.services.credentialStore.updateCredential(credential, completion: { result in
+                    switch result {
+                    case .success:
+                        self?.goForward()
+                    case .failure(let error):
+                        self?.show(error)
+                    }
+                })
+            case .failure(let error):
+                self?.show(error)
+            }
+        }
+    }
+}
+
+struct ROPCResponse: Decodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case scope = "scope"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+    }
+    
+    let accessToken: String
+    let refreshToken: String
+    let scope: String
+    let tokenType: String
+    let expiresIn: Int
+}

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -60,10 +60,7 @@ extension MWAppAuthStepViewController {
     }
     
     private func performOAuthROPCRequest(config: OAuthROPCConfig, username: String, password: String) {
-        guard
-            let tokenUrlString = config.oAuth2TokenUrl,
-            let tokenURL = self.appAuthStep.session.resolve(url: tokenUrlString)
-        else { return }
+        guard let tokenURL = self.appAuthStep.session.resolve(url: config.oAuth2TokenUrl) else { return }
         
         var params: [String: String] = [
             "grant_type": "password",

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Future Workshops. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import MobileWorkflowCore
 import AppAuth
 import Combine
@@ -27,8 +27,12 @@ class MWAppAuthStepViewController: ORKTableStepViewController, WorkflowPresentat
     }
     
     private var ongoingImageLoads: [IndexPath: AnyCancellable] = [:]
-    private var appleAccessTokenURL: String?
-    private var appleUsername: String?
+    var appleAccessTokenURL: String?
+    var appleUsername: String?
+    
+    private(set) lazy var ropcNetworkService: NetworkAsyncTaskService = {
+        NetworkAsyncTaskService(urlSession: .shared)
+    }()
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -80,66 +84,6 @@ class MWAppAuthStepViewController: ORKTableStepViewController, WorkflowPresentat
         }
     }
     
-    // OAuth2
-    
-    private func performOAuth(config: OAuth2Config) {
-        guard
-            let oAuth2Url = self.appAuthStep.session.resolve(url: config.oAuth2Url)?.absoluteString,
-            let authorizationEndpoint = URL(string: oAuth2Url.appending(OAuthPaths.authorization)),
-            let tokenEndpoint = URL(string: oAuth2Url.appending(OAuthPaths.token)),
-            let redirectURL = URL(string: config.oAuth2RedirectScheme + "://callback")
-            else { return }
-        
-        self.showLoading()
-        
-        let configuration = OIDServiceConfiguration(
-            authorizationEndpoint: authorizationEndpoint,
-            tokenEndpoint: tokenEndpoint
-        )
-        
-        let request = OIDAuthorizationRequest(
-            configuration: configuration,
-            clientId: config.oAuth2ClientId,
-            clientSecret: (config.oAuth2ClientSecret?.isEmpty ?? true) ? nil : config.oAuth2ClientSecret,
-            scopes: [config.oAuth2Scope],
-            redirectURL: redirectURL,
-            responseType: OIDResponseTypeCode,
-            additionalParameters: nil
-        )
-        
-        let authProvider = AuthProviderImplementation() { completion in
-            let session = OIDAuthState.authState(byPresenting: request, presenting: self) { authState, error in
-                if let authState = authState, let accessToken = authState.lastTokenResponse?.accessToken, let  expirationDate = authState.lastTokenResponse?.accessTokenExpirationDate {
-                    let token = Credential(
-                        type: CredentialType.token.rawValue,
-                        value: accessToken,
-                        expirationDate: expirationDate
-                    )
-                    completion(.success(token))
-                } else {
-                    completion(.failure(error ?? CredentialError.unexpected))
-                }
-            }
-            return AppAuthFlowResumer(session: session)
-        }
-        let authenticationTask = AuthenticationTask(input: authProvider)
-        self.appAuthStep?.services.perform(task: authenticationTask, session: self.appAuthStep.session) { [weak self] (response) in
-            DispatchQueue.main.async {
-                self?.hideLoading()
-                switch response {
-                case .success:
-                    self?.goForward()
-                case .failure(let error):
-                    if let authError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? ASWebAuthenticationSessionError, authError.code == .canceledLogin {
-                        // if cancel, do nothing
-                    } else {
-                        self?.show(error)
-                    }
-                }
-            }
-        }
-    }
-    
     // MARK: Loading
     
     public func showLoading() {
@@ -164,6 +108,8 @@ extension MWAppAuthStepViewController: MobileWorkflowButtonTableViewCellDelegate
         switch representation {
         case .oauth(_, let config):
             self.performOAuth(config: config)
+        case .oauthRopc(_, let config):
+            self.performOAuthROPC(config: config)
         case .twitter(_):
             break // TODO: perform twitter login
         case .modalWorkflowId(_,  let modalWorkflowId):
@@ -175,191 +121,5 @@ extension MWAppAuthStepViewController: MobileWorkflowButtonTableViewCellDelegate
         case .apple:
             break
         }
-    }
-}
-
-// MARK: - Sign in with Apple
-
-extension MWAppAuthStepViewController: SignInWithAppleButtonTableViewCellDelegate {
-    func appleCell(_ cell: SignInWithAppleButtonTableViewCell, didTapButton button: UIButton) {
-        guard let indexPath = self.tableView?.indexPath(for: cell), let item = self.appAuthStep.objectForRow(at: indexPath) as? AuthItem, let representation = try? item.respresentation() else { return }
-        
-        switch representation {
-        case .apple:
-            self.appleAccessTokenURL = item.appleAccessTokenURL
-            self.handleDidTapSignInWithApple(needsFullName: item.appleFullNameScope ?? false, needsEmail: item.appleEmailScope ?? false)
-        default:
-            break
-        }
-    }
-}
-
-private extension MWAppAuthStepViewController {
-    
-    func handleDidTapSignInWithApple(needsFullName: Bool, needsEmail: Bool) {
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        let request = appleIDProvider.createRequest()
-        request.requestedScopes = []
-        
-        if needsFullName {
-            request.requestedScopes?.append(.fullName)
-        }
-        
-        if needsEmail {
-            request.requestedScopes?.append(.email)
-        }
-        
-        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-        authorizationController.delegate = self
-        authorizationController.presentationContextProvider = self
-        
-        authorizationController.performRequests()
-    }
-    
-    func performSignInWithApple(userId: String, name: String, identityToken: String) {
-        
-        let appleCredential = AppleIDCredential(userId: userId, name: name, identityToken: identityToken)
-        
-        guard let urlString = self.appleAccessTokenURL,
-              let url = self.appAuthStep.session.resolve(url: urlString)
-        else {
-            return
-        }
-        
-        let data = try? JSONEncoder().encode(appleCredential)
-        
-        let parser: (Data) throws -> Credential = { data in
-            return try JSONDecoder().decode(Credential.self, from: data)
-        }
-        
-        let authTask = URLAsyncTask<Credential>.build(url: url, method: .POST, body: data, session: self.appAuthStep.session, parser: parser)
-        
-        self.appAuthStep?.services.perform(task: authTask, session: self.appAuthStep.session) { [weak self] (response) in
-            DispatchQueue.main.async {
-                self?.hideLoading()
-                switch response {
-                case .success(let credential):
-                    self?.appAuthStep.services.credentialStore.updateCredential(credential, completion: { result in
-                        switch result {
-                        case .success:
-                            self?.goForward()
-                        case .failure(let error):
-                            self?.show(error)
-                        }
-                    })
-                case .failure(let error):
-                    self?.show(error)
-                }
-            }
-        }
-    }
-    
-    func makeName(fullName: PersonNameComponents?) -> String {
-        guard let fullName = fullName else {
-            return ""
-        }
-        
-        var nameComponents = [String]()
-        if let givenName = fullName.givenName {
-            nameComponents.append(givenName)
-        }
-        if let familyName = fullName.familyName {
-            nameComponents.append(familyName)
-        }
-        
-        if nameComponents.isEmpty {
-            return self.appleUsername ?? ""
-        } else {
-            let name = nameComponents.joined(separator: " ")
-            self.appleUsername = name
-            
-            return name
-        }
-    }
-}
-
-struct AppleIDCredential: Codable {
-    let userId: String
-    let name: String
-    let identityToken: String
-    
-    enum CodingKeys: String, CodingKey {
-        case userId = "user_identity"
-        case name = "name"
-        case identityToken = "jwt"
-    }
-}
-
-// MARK: - Authorization Controller Delegate
-
-extension MWAppAuthStepViewController: ASAuthorizationControllerDelegate {
-    
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        
-        switch authorization.credential {
-        case let appleIDCredential as ASAuthorizationAppleIDCredential:
-            
-            // Name is only provided in the first response of an Auth request. Save it in case multiple attempts are required
-            let name = self.makeName(fullName: appleIDCredential.fullName)
-            
-            guard let identityToken = appleIDCredential.identityToken, let identityTokenString = String(data: identityToken, encoding: .utf8) else {
-                self.showConfirmationAlert(title: L10n.AppleLogin.errorTitle, message: L10n.AppleLogin.errorMessage) { _ in }
-                return
-            }
-            
-            // Expiration date is not currently used, hence credential was set to `.distantFuture`. This should be reviewed in the future.
-            let userIdCredential = Credential(
-                type: CredentialType.appleIdCredentialUser.rawValue,
-                value: appleIDCredential.user,
-                expirationDate: .distantFuture
-            )
-
-            self.appAuthStep.services.credentialStore.updateCredential(userIdCredential) { [weak self] result in
-                switch result {
-                case .success:
-                    self?.performSignInWithApple(userId: appleIDCredential.user, name: name, identityToken: identityTokenString)
-                    
-                case .failure(let error):
-                    self?.show(error)
-                }
-            }
-            
-        default:
-            break
-        }
-    }
-    
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        guard let authError = error as? ASAuthorizationError, authError.code != .canceled else {
-            return
-        }
-        
-        self.showConfirmationAlert(title: L10n.AppleLogin.errorTitle, message: L10n.AppleLogin.errorMessage) { _ in }
-    }
-}
-
-// MARK: - Authorization Controller Presentation
-
-extension MWAppAuthStepViewController: ASAuthorizationControllerPresentationContextProviding {
-    
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        guard let windows = self.view.window else {
-            preconditionFailure()
-        }
-        
-        return windows
-    }
-}
-
-class AppAuthFlowResumer: AuthFlowResumer {
-    
-    private var session: OIDExternalUserAgentSession?
-    
-    init(session: OIDExternalUserAgentSession) {
-        self.session = session
-    }
-    
-    func resumeAuth(with url: URL) -> Bool {
-        return self.session?.resumeExternalUserAgentFlow(with: url) ?? false
     }
 }

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -88,12 +88,10 @@ class MWAppAuthStepViewController: ORKTableStepViewController, WorkflowPresentat
     
     public func showLoading() {
         self.tableView?.isUserInteractionEnabled = false
-        self.tableView?.backgroundView = StateView(frame: .zero)
     }
 
     public func hideLoading() {
         self.tableView?.isUserInteractionEnabled = true
-        self.tableView?.backgroundView = nil
     }
 }
 

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -108,8 +108,8 @@ extension MWAppAuthStepViewController: MobileWorkflowButtonTableViewCellDelegate
         switch representation {
         case .oauth(_, let config):
             self.performOAuth(config: config)
-        case .oauthRopc(_, let config):
-            self.performOAuthROPC(config: config)
+        case .oauthRopc(let buttonTitle, let config):
+            self.performOAuthROPC(title: buttonTitle, config: config)
         case .twitter(_):
             break // TODO: perform twitter login
         case .modalWorkflowId(_,  let modalWorkflowId):

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - MobileWorkflow (0.0.86):
-    - MobileWorkflow/Core (= 0.0.86)
-  - MobileWorkflow/Core (0.0.86)
+  - MobileWorkflow (0.0.93):
+    - MobileWorkflow/Core (= 0.0.93)
+  - MobileWorkflow/Core (0.0.93)
 
 DEPENDENCIES:
   - AppAuth
@@ -20,7 +20,7 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  MobileWorkflow: b92456c69dde469794fa62b0e1760fb7fa741d8f
+  MobileWorkflow: c55fe7037f4581e11b498da5542c927c1fe238e1
 
 PODFILE CHECKSUM: 9fd624c0682bc7385505d19d5b938a4e88a5e129
 


### PR DESCRIPTION
Now supporting `oauthRopc` auth type.

On button tap, a username/password form will be presented, once entered, the form will be dismissed the main auth step will attempt to login. If successful the auth step will 'complete'.