### PR TITLE
Change workshop id type to string

### DIFF
--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/AuthItem.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/AuthItem.swift
@@ -39,7 +39,7 @@ class AuthItem: NSObject, Codable, NSCopying, NSCoding, NSSecureCoding {
     let oAuth2Scope: String?
     let oAuth2RedirectScheme: String?
     let oAuth2TokenUrl: String?
-    let modalWorkflowId: Int?
+    let modalWorkflowId: String?
     let appleFullNameScope: Bool?
     let appleEmailScope: Bool?
     let appleAccessTokenURL: String?
@@ -61,7 +61,7 @@ class AuthItem: NSObject, Codable, NSCopying, NSCoding, NSSecureCoding {
         let oAuth2Scope = coder.decodeObject(of: NSString.self, forKey: kOAuth2Scope)
         let oAuth2RedirectScheme = coder.decodeObject(of: NSString.self, forKey: kOAuth2RedirectScheme)
         let oAuth2TokenUrl = coder.decodeObject(of: NSString.self, forKey: kOAuth2TokenUrl)
-        let modalWorkflowId = coder.decodeObject(of: NSNumber.self, forKey: kModalWorkflowId)
+        let modalWorkflowId = coder.decodeObject(of: NSString.self, forKey: kModalWorkflowId)
         let appleFullNameScope = coder.decodeObject(forKey: kAppleFullNameScope) as? Bool
         let appleEmailScope = coder.decodeObject(forKey: kAppleEmailScope) as? Bool
         let appleAccessTokenURL = coder.decodeObject(of: NSString.self, forKey: kAppleAccessTokenURL)
@@ -75,14 +75,14 @@ class AuthItem: NSObject, Codable, NSCopying, NSCoding, NSSecureCoding {
             oAuth2Scope: oAuth2Scope as String?,
             oAuth2RedirectScheme: oAuth2RedirectScheme as String?,
             oAuth2TokenUrl: oAuth2TokenUrl as String?,
-            modalWorkflowId: modalWorkflowId?.intValue,
+            modalWorkflowId: modalWorkflowId as String?,
             appleFullNameScope: appleFullNameScope,
             appleEmailScope: appleEmailScope,
             appleAccessTokenURL: appleAccessTokenURL as String?
         )
     }
     
-    init(type: ItemType, buttonTitle: String, oAuth2Url: String?, oAuth2ClientId: String?, oAuth2ClientSecret: String?, oAuth2Scope: String?, oAuth2RedirectScheme: String?, oAuth2TokenUrl: String?, modalWorkflowId: Int?, appleFullNameScope: Bool?, appleEmailScope: Bool?, appleAccessTokenURL: String?) {
+    init(type: ItemType, buttonTitle: String, oAuth2Url: String?, oAuth2ClientId: String?, oAuth2ClientSecret: String?, oAuth2Scope: String?, oAuth2RedirectScheme: String?, oAuth2TokenUrl: String?, modalWorkflowId: String?, appleFullNameScope: Bool?, appleEmailScope: Bool?, appleAccessTokenURL: String?) {
 
         self.type = type
         self.buttonTitle = buttonTitle
@@ -151,7 +151,7 @@ enum AuthItemRepresentation {
     case oauth(buttonTitle: String, config: OAuth2Config)
     case oauthRopc(buttonTitle: String, config: OAuthROPCConfig)
     case twitter(buttonTitle: String)
-    case modalWorkflowId(buttonTitle: String, modalWorkflowId: Int)
+    case modalWorkflowId(buttonTitle: String, modalWorkflowId: String)
     case apple
     
     var buttonTitle: String {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -185,12 +185,7 @@ extension MWAppAuthStep: MobileWorkflowStep {
             let oAuth2RedirectScheme = content["oAuth2RedirectScheme"] as? String
             let oAuth2TokenUrl = content["oAuth2TokenUrl"] as? String
             
-            let modalWorkflowId: Int?
-            if let id = content["modalWorkflowId"] as? String, id.isEmpty == false {
-                modalWorkflowId = Int(id)
-            } else {
-                modalWorkflowId = content["modalWorkflowId"] as? Int
-            }
+            let modalWorkflowId = content.getString(key: "modalWorkflowId")
             
             let appleFullNameScope = content["appleFullNameScope"] as? Bool
             let appleEmailScope = content["appleEmailScope"] as? Bool


### PR DESCRIPTION
With the latest change in the core to have workshop ID as a string, this plugin needs to be updated to match the new interfaces.