### PR TITLE
Dismiss login options after sign up modal flow if token present

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.0.26'
+    s.version               = '0.0.27'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -128,8 +128,9 @@ extension MWAppAuthStepViewController: MWButtonTableViewCellDelegate {
             break // TODO: perform twitter login
         case .modalWorkflowId(_,  let modalWorkflowId):
             self.workflowPresentationDelegate?.presentWorkflowWithId(modalWorkflowId, isDiscardable: true, animated: true, onDismiss: { reason in
-                if reason == .completed {
-                    // do nothing, user will likely now need to login
+                if reason == .completed,
+                   let _ = try? self.appAuthStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get() {
+                    self.goForward() // i.e. dismiss login options
                 }
             })
         case .apple:


### PR DESCRIPTION
i.e. if the response was intercepted and the token information extracted and stored successfully.