### PR TITLE
Task/mw 1719

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.0.28'
+    s.version               = '0.0.29'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -11,7 +11,7 @@ import MobileWorkflowCore
 
 enum L10n {
     enum AppAuth {
-        static let loginTitle = "Log In"
+        static let loginTitle = "Continue"
         static func invalidStepDataError(cause: String) -> String {
             "Invalid step data: \(cause)"
         }
@@ -21,6 +21,7 @@ enum L10n {
         static let loginDetailsTitle = "Please enter your login details:"
         static let usernameFieldTitle = "Username"
         static let passwordFieldTitle = "Password"
+        static let required = "Required"
     }
     
     enum AppleLogin {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -80,17 +80,25 @@ extension MWAppAuthStepViewController {
             loginViewController.hideLoading()
             switch result {
             case .success(let response):
+                
                 let token = Credential(
                     type: CredentialType.token.rawValue,
                     value: response.accessToken,
                     expirationDate: Date().addingTimeInterval(TimeInterval(response.expiresIn))
                 )
-                let refresh = Credential(
-                    type: CredentialType.refreshToken.rawValue,
-                    value: response.refreshToken,
-                    expirationDate: .distantFuture
-                )
-                self?.appAuthStep.services.credentialStore.updateCredentials([token, refresh], completion: { [weak self] result in
+                
+                var tokens : [Credential] = [token]
+                
+                if let refreshToken = response.refreshToken, refreshToken.isEmpty == false {
+                    let refresh = Credential(
+                        type: CredentialType.refreshToken.rawValue,
+                        value: refreshToken,
+                        expirationDate: .distantFuture
+                    )
+                    tokens.append(refresh)
+                }
+                
+                self?.appAuthStep.services.credentialStore.updateCredentials(tokens, completion: { [weak self] result in
                     switch result {
                     case .success:
                         loginViewController.goForward()
@@ -117,7 +125,7 @@ struct ROPCResponse: Decodable {
     }
     
     let accessToken: String
-    let refreshToken: String
+    let refreshToken: String?
     let scope: String
     let tokenType: String
     let expiresIn: Int

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -30,36 +30,28 @@ extension MWAppAuthStepViewController {
     
     func performOAuthROPC(title: String, config: OAuthROPCConfig) {
         
-        let headerTitleItem = ORKFormItem(sectionTitle: L10n.AppAuth.loginDetailsTitle)
-        
-        let usernameAnswerFormat = ORKTextAnswerFormat()
-        usernameAnswerFormat.multipleLines = false
-        usernameAnswerFormat.autocapitalizationType = .none
-        usernameAnswerFormat.autocorrectionType = .no
-        usernameAnswerFormat.textContentType = .username
-        let usernameFormItem = ORKFormItem(identifier: kUsernameItemIdentifier, text: L10n.AppAuth.usernameFieldTitle, answerFormat: usernameAnswerFormat)
-        usernameFormItem.isOptional = false
-        
-        let passwordAnswerFormat = ORKTextAnswerFormat()
-        passwordAnswerFormat.isSecureTextEntry = true
-        passwordAnswerFormat.textContentType = .password
-        passwordAnswerFormat.multipleLines = false
-        let passwordFormItem = ORKFormItem(identifier: kPasswordItemIdentifier, text: L10n.AppAuth.passwordFieldTitle, answerFormat: passwordAnswerFormat)
-        passwordFormItem.isOptional = false
-        
-        let step = ORKFormStep(identifier: kFormStepIdentifier, title: title.capitalized, text: nil)
-        step.formItems = [headerTitleItem, usernameFormItem, passwordFormItem]
-        step.isOptional = false
-        
+        let step = ROPCStep(identifier: kFormStepIdentifier,
+                            title: title,
+                            text: self.appAuthStep.text,
+                            imageURL: self.appAuthStep.imageURL,
+                            services: self.appAuthStep.services,
+                            session: self.appAuthStep.session.copyForChild(),
+                            submitBlock: { [weak self] (loginViewController, credentials) in
+            self?.performOAuthROPCRequest(config: config,
+                                          username: credentials.username,
+                                          password: credentials.password,
+                                          loginViewController: loginViewController)
+        })
+
         let workflow = MWWorkflow(identifier: kFormTaskIdentifier, steps: [step], id: kFormTaskIdentifier, name: nil, title: nil, systemImageName: nil, session: self.appAuthStep.session.copyForChild())
         let vc = ROPCFormTaskViewController(workflow: workflow, config: config)
         vc.isDiscardable = true
         vc.workflowDelegate = self
-        
+
         self.present(vc, animated: true, completion: nil)
     }
     
-    private func performOAuthROPCRequest(config: OAuthROPCConfig, username: String, password: String) {
+    private func performOAuthROPCRequest(config: OAuthROPCConfig, username: String, password: String, loginViewController: MWROPCLoginViewController) {
         guard let tokenURL = self.appAuthStep.session.resolve(url: config.oAuth2TokenUrl) else { return }
         
         var params: [String: String] = [
@@ -83,9 +75,9 @@ extension MWAppAuthStepViewController {
             parser: { try ROPCResponse.parse(data: $0) }
         )
         
-        self.showLoading()
+        loginViewController.showLoading()
         self.ropcNetworkService.perform(task: task, session: self.appAuthStep.session, respondOn: .main) { [weak self] result in
-            self?.hideLoading()
+            loginViewController.hideLoading()
             switch result {
             case .success(let response):
                 let token = Credential(
@@ -101,16 +93,17 @@ extension MWAppAuthStepViewController {
                 self?.appAuthStep.services.credentialStore.updateCredentials([token, refresh], completion: { [weak self] result in
                     switch result {
                     case .success:
-                        self?.goForward()
+                        loginViewController.goForward()
                     case .failure(let error):
-                        self?.show(error)
+                        loginViewController.show(error)
                     }
                 })
             case .failure(let error):
-                self?.show(error)
+                loginViewController.show(error)
             }
         }
     }
+    
 }
 
 struct ROPCResponse: Decodable {
@@ -139,21 +132,19 @@ extension MWAppAuthStepViewController: WorkflowViewControllerDelegate {
     func workflowViewController(_ workflowViewController: WorkflowViewController, didFinishWith reason: WorkflowFinishReason) {
         workflowViewController.presentingViewController?.dismiss(animated: true) { [weak self] in
             #warning("This data extraction from session needs to be tested")
-            guard reason == .completed,
-                  let config = (workflowViewController as? ROPCFormTaskViewController)?.config,
-                  let username = workflowViewController.workflow.session.fetchValue(resource: "\(kUsernameItemIdentifier).answer") as? String,
-                  let password = workflowViewController.workflow.session.fetchValue(resource: "\(kPasswordItemIdentifier).answer") as? String
-            else { return }
-            self?.performOAuthROPCRequest(config: config, username: username, password: password)
+            
+            if reason == .completed {
+                self?.goForward()
+            }
+
         }
     }
     
     func workflowViewController(_ workflowViewController: WorkflowViewController, stepViewControllerWillAppear stepViewController: StepViewController) {
-        guard let stepViewController = stepViewController as? ORKStepViewController else { preconditionFailure() }
-        stepViewController.continueButtonItem?.title = L10n.AppAuth.loginTitle
+        
     }
     
     func workflowViewController(_ workflowViewController: WorkflowViewController, stepViewControllerWillDisappear stepViewController: StepViewController) {
-        // nothing
+        
     }
 }

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -1,0 +1,409 @@
+//
+//  MWAppAuthLoginViewController.swift
+//  MWAppAuthPlugin
+//
+//  Created by Julien Hebert on 18/10/2021.
+//
+
+import UIKit
+import Combine
+import MobileWorkflowCore
+
+typealias Credentials = (username: String, password: String)
+typealias SubmitBlock = (MWROPCLoginViewController, Credentials) -> Void
+
+final class ROPCStep: MWStep {
+    let imageURL: String?
+    let services: StepServices
+    let session: Session
+    let submitBlock : SubmitBlock?
+    
+    init(identifier: String,
+         title: String?,
+         text: String?,
+         imageURL: String?,
+         services: StepServices,
+         session: Session,
+         submitBlock : SubmitBlock?) {
+        self.imageURL = (imageURL?.isEmpty ?? true) ? nil : imageURL
+        self.services = services
+        self.session = session
+        self.submitBlock = submitBlock
+        super.init(identifier: identifier)
+        self.title = title
+        self.text = text
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func instantiateViewController() -> StepViewController {
+        return MWROPCLoginViewController(ropcStep: self)
+    }
+    
+}
+
+final class MWROPCLoginViewController: MWContentStepViewController {
+    
+    public override var titleMode: StepViewControllerTitleMode { .largeTitle }
+    private var scrollView: UIScrollView!
+    private var contentStackView: UIStackView!
+    private var imageView: UIImageView!
+    private var loadingView: StateView!
+    
+    private lazy var bodyLabel: StepBodyLabel = {
+        let bodyLabel = StepBodyLabel()
+        bodyLabel.numberOfLines = 0
+        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
+        bodyLabel.textColor = self.ropcStep.theme.primaryTextColor
+        return bodyLabel
+    }()
+
+    private lazy var usernameField: MWROPCTextField = {
+        let usernameField = MWROPCTextField(theme: self.ropcStep.theme)
+        let emailConfig = MWROPCTextField.Config(title: L10n.AppAuth.usernameFieldTitle,
+                                                 placeholder: L10n.AppAuth.required,
+                                                 textContentType: .username)
+        
+        usernameField.configure(config: emailConfig)
+        usernameField.delegate = self
+        return usernameField
+    }()
+    
+    private lazy var passwordField: MWROPCTextField = {
+        let passwordField = MWROPCTextField(theme: self.ropcStep.theme)
+        let passwordConfig = MWROPCTextField.Config(title: L10n.AppAuth.passwordFieldTitle,
+                                                    placeholder: L10n.AppAuth.required,
+                                                    isSecureTextEntry: true,
+                                                    textContentType: .password)
+        passwordField.configure(config: passwordConfig)
+        passwordField.delegate = self
+        return passwordField
+    }()
+    
+    private lazy var separatorLine: UIView = {
+        let separatorLine = UIView()
+        separatorLine.backgroundColor = self.ropcStep.theme.groupedBackgroundColor
+        separatorLine.translatesAutoresizingMaskIntoConstraints = false
+        return separatorLine
+    }()
+    
+    private lazy var loginButton: CustomButton = {
+        let button = CustomButton(style: .primary, theme: self.ropcStep.theme)
+        button.setTitle(L10n.AppAuth.loginTitle, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(self.submit), for: .touchUpInside)
+        button.isEnabled = false
+        return button
+    }()
+    
+    private var imageLoad: AnyCancellable?
+    
+    private var imageViewHeightConstraint: NSLayoutConstraint?
+    private var constraints: [NSLayoutConstraint] = [] {
+        didSet {
+            NSLayoutConstraint.deactivate(oldValue)
+            NSLayoutConstraint.activate(self.constraints)
+        }
+    }
+    
+    private var ropcStep: ROPCStep {
+        self.mwStep as! ROPCStep
+    }
+    
+    public init(ropcStep: ROPCStep) {
+        super.init(step: ropcStep)
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.title = self.ropcStep.title
+        self.setupUI()
+        self.registerForKeyboardNotifications(self.scrollView, bottomMargin: 20.0)
+        self.configureTapOutsideToDismiss()
+    }
+    
+    private func setupUI() {
+        self.hideNavigationFooterView()
+        self.configureImageView(imageUrl: self.ropcStep.imageURL, image: nil)
+        let body = self.ropcStep.session.resolve(value: self.ropcStep.text ?? "")
+        self.bodyLabel.text = body.isEmpty ? L10n.AppAuth.loginDetailsTitle : body
+        self.configureStackView()
+        self.setupLoadingView()
+        self.configureConstraints()
+        self.configureStyle()
+    }
+    
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        self.configureStyle()
+    }
+
+    private func configureImageView(imageUrl: String?, image: UIImage?) {
+        self.imageView = self.imageView ?? UIImageView()
+        self.imageView.backgroundColor = self.ropcStep.theme.imagePlaceholderBackgroundColor
+        self.imageView.clipsToBounds = true
+        self.imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        if image == nil, let imageUrl = imageUrl {
+            self.imageLoad = self.ropcStep.services.imageLoadingService.asyncLoad(image: imageUrl, session: self.ropcStep.session) { [weak self] in
+                self?.updateImage($0, showPlaceholder: false)
+                self?.imageLoad = nil
+            }
+            if self.imageView.image == nil {
+                self.updateImage(nil, showPlaceholder: true)
+            }
+        } else {
+            self.updateImage(image, showPlaceholder: false)
+        }
+    }
+    
+    private func updateImage(_ image: UIImage?, showPlaceholder: Bool) {
+        if image == nil, showPlaceholder {
+            let imageConfig = UIImage.SymbolConfiguration(textStyle: .largeTitle)
+            let image = UIImage(systemName: "photo", withConfiguration: imageConfig)
+            self.imageView.image = image
+            self.imageView.contentMode = .center
+        } else {
+            self.imageView.image = image
+            self.imageView.contentMode = .scaleAspectFill
+        }
+        let heightMultiplier: CGFloat = self.imageView.image == nil ? 0.0 : 0.3
+        self.imageViewHeightConstraint = self.imageView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: heightMultiplier)
+        
+        self.imageView.isHidden = self.imageView.image == nil
+    }
+    
+    private func configureStackView() {
+        
+        let separatorLineStackView = UIStackView( arrangedSubviews: [self.separatorLine])
+        separatorLineStackView.isLayoutMarginsRelativeArrangement = true
+        separatorLineStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0)
+        
+        let fieldsStackView = UIStackView(
+            arrangedSubviews: [
+                self.usernameField,
+                separatorLineStackView,
+                self.passwordField
+            ]
+        )
+        fieldsStackView.backgroundColor = .white
+        fieldsStackView.layer.cornerRadius = 8.0
+        fieldsStackView.clipsToBounds = true
+        fieldsStackView.translatesAutoresizingMaskIntoConstraints = false
+        fieldsStackView.axis = .vertical
+        fieldsStackView.alignment = .fill
+        fieldsStackView.spacing = 0
+        
+        // container to ensure top alignment
+        let containerStackView = UIStackView(
+            arrangedSubviews: [self.bodyLabel, fieldsStackView, self.loginButton]
+        )
+        containerStackView.translatesAutoresizingMaskIntoConstraints = false
+        containerStackView.axis = .vertical
+        containerStackView.alignment = .fill
+        containerStackView.spacing = 20
+        containerStackView.isLayoutMarginsRelativeArrangement = true
+        containerStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+        
+        let contentStackView = UIStackView(
+            arrangedSubviews: [
+                self.imageView,
+                containerStackView
+            ]
+        )
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.axis = .vertical
+        contentStackView.alignment = .fill
+        contentStackView.spacing = 16
+        contentStackView.isLayoutMarginsRelativeArrangement = true
+        contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 30, leading: 0, bottom: 30, trailing: 0)
+        
+        self.contentStackView?.removeFromSuperview()
+        self.contentStackView = contentStackView
+        
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(contentStackView)
+        
+        self.scrollView?.removeFromSuperview()
+        self.scrollView = scrollView
+        self.contentView.addSubview(scrollView)
+    }
+    
+    private func setupLoadingView() {
+        self.loadingView = self.loadingView ?? StateView(frame: .zero)
+        self.loadingView.configure(isLoading: true, theme: self.mwStep.theme)
+        self.loadingView.translatesAutoresizingMaskIntoConstraints = false
+        self.loadingView.backgroundColor = .clear
+        self.contentView.addSubview(self.loadingView)
+        self.hideLoading()
+    }
+    
+    private func configureConstraints() {
+
+        var constraints = [NSLayoutConstraint]()
+
+        if let imageViewHeightConstraint = self.imageViewHeightConstraint {
+            constraints.append(imageViewHeightConstraint)
+        }
+        
+        let buttonHeightConstraint = self.loginButton.heightAnchor.constraint(equalToConstant: 50)
+        buttonHeightConstraint.priority = .init(rawValue: 999)
+        buttonHeightConstraint.isActive = true
+        
+        let lineHeightConstraint = self.separatorLine.heightAnchor.constraint(equalToConstant: 1)
+        lineHeightConstraint.priority = .init(rawValue: 999)
+        lineHeightConstraint.isActive = true
+        
+        let scrollViewConstraints = [
+            self.scrollView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+            self.scrollView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+            self.scrollView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+            self.scrollView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+        ]
+        constraints.append(contentsOf: scrollViewConstraints)
+        
+        let contentStackViewConstraints = [
+            self.contentStackView.topAnchor.constraint(equalTo: self.scrollView.topAnchor),
+            self.contentStackView.leadingAnchor.constraint(equalTo: self.scrollView.leadingAnchor),
+            self.contentStackView.trailingAnchor.constraint(equalTo: self.scrollView.trailingAnchor),
+            self.contentStackView.bottomAnchor.constraint(equalTo: self.scrollView.bottomAnchor),
+            self.contentStackView.widthAnchor.constraint(equalTo: self.scrollView.widthAnchor)
+        ]
+        constraints.append(contentsOf: contentStackViewConstraints)
+        
+        let loadingViewConstraints = [
+            self.loadingView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+            self.loadingView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+            self.loadingView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+            self.loadingView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+        ]
+        constraints.append(contentsOf: loadingViewConstraints)
+        
+        self.constraints = constraints
+    }
+    
+    private func configureStyle() {
+        self.view.backgroundColor = self.ropcStep.theme.groupedBackgroundColor
+        self.parent?.view.backgroundColor = self.ropcStep.theme.groupedBackgroundColor
+        self.contentView.backgroundColor = .clear
+        self.navigationFooterView.backgroundColor = .clear
+    }
+    
+    private func configureTapOutsideToDismiss(){
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.tappedOutsideResponsiveView))
+        tapGesture.cancelsTouchesInView = false
+        self.view.addGestureRecognizer(tapGesture)
+    }
+    
+    public override func configureNavigationBar(_ navigationBar: UINavigationBar) {
+        self.configureNavBarAsDefaultGrouped(withTheme: self.ropcStep.theme)
+    }
+    
+    // MARK: Loading
+    
+    public func showLoading() {
+        self.loginButton.isEnabled = false
+        self.loadingView.isHidden = false
+    }
+
+    public func hideLoading() {
+        self.loginButton.isEnabled = self.isValid
+        self.loadingView.isHidden = true
+    }
+    
+    private var credentials : Credentials? {
+        guard let username = self.usernameField.value, username.isEmpty == false else {return nil}
+        guard let password = self.passwordField.value, password.isEmpty == false else {return nil}
+        return (username, password)
+    }
+    
+    private var isValid : Bool {
+        return self.credentials != nil
+    }
+    
+    private func validateForm(){
+        self.loginButton.isEnabled = self.isValid
+    }
+    
+    @IBAction func tappedOutsideResponsiveView(){
+        self.view.endEditing(false)
+    }
+    
+    @IBAction func submit(){
+        guard let credentials = self.credentials else {return}
+        self.ropcStep.submitBlock?(self, credentials)
+    }
+}
+
+extension UIViewController {
+    
+    fileprivate func registerForKeyboardNotifications(_ scrollView: UIScrollView?, bottomMargin: CGFloat = 0){
+        self.registerForKeyboardWillShowNotification(scrollView, bottomMargin: bottomMargin)
+        self.registerForKeyboardWillHideNotification(scrollView)
+    }
+    
+    private func registerForKeyboardWillShowNotification(_ scrollView: UIScrollView? = nil, bottomMargin: CGFloat = 0, usingBlock block: ((CGSize?) -> Void)? = nil) {
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: nil, using: { notification -> Void in
+            let userInfo = notification.userInfo!
+            let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey]! as AnyObject).cgRectValue.size
+            
+            if let scrollView = scrollView {
+                let bottomSafeAreaInset = scrollView.superview?.safeAreaInsets.bottom ?? 0
+                let contentInsets = UIEdgeInsets(top: scrollView.contentInset.top, left: scrollView.contentInset.left, bottom: keyboardSize.height + bottomMargin - bottomSafeAreaInset, right: scrollView.contentInset.right)
+                scrollView.setContentInsetAndScrollIndicatorInsets(contentInsets)
+            }
+            
+            block?(keyboardSize)
+        })
+    }
+    
+    private func registerForKeyboardWillHideNotification(_ scrollView: UIScrollView? = nil, usingBlock block: (() -> Void)? = nil) {
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil, using: { _ -> Void in
+            
+            if let scrollView = scrollView {
+                let contentInsets = UIEdgeInsets(top: scrollView.contentInset.top, left: scrollView.contentInset.left, bottom: 0, right: scrollView.contentInset.right)
+                scrollView.setContentInsetAndScrollIndicatorInsets(contentInsets)
+            }
+            
+            block?()
+        })
+    }
+    
+}
+
+extension UIScrollView {
+    
+    fileprivate func setContentInsetAndScrollIndicatorInsets(_ edgeInsets: UIEdgeInsets) {
+        self.contentInset = edgeInsets
+        self.scrollIndicatorInsets = edgeInsets
+    }
+    
+}
+
+extension MWROPCLoginViewController: MWROPCTextFieldDelegate {
+    
+    func onReturnTapped(textField: MWROPCTextField) {
+        if textField === self.usernameField {
+            self.passwordField.becomeFirstResponder()
+        }else if textField === self.passwordField {
+            if self.isValid {
+                self.submit()
+            }else{
+                textField.resignFirstResponder()
+            }
+        }
+    }
+    
+    func valueDidChange(textField: MWROPCTextField) {
+        self.validateForm()
+    }
+    
+}

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCTextField.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCTextField.swift
@@ -1,0 +1,138 @@
+//
+//  MWROPCTextField.swift
+//  MWAppAuthPlugin
+//
+//  Created by Julien Hebert on 20/10/2021.
+//
+
+import UIKit
+import MobileWorkflowCore
+
+public protocol MWROPCTextFieldDelegate : class {
+    func onReturnTapped(textField: MWROPCTextField)
+    func valueDidChange(textField: MWROPCTextField)
+}
+
+public class MWROPCTextField: UIView {
+    
+    public weak var delegate : MWROPCTextFieldDelegate?
+    
+    public struct Config {
+        public let title: String
+        public let placeholder: String?
+        public let isSecureTextEntry: Bool
+        public let textContentType: UITextContentType
+        
+        public init(
+            title: String,
+            placeholder: String?,
+            isSecureTextEntry: Bool = false,
+            textContentType: UITextContentType
+        ) {
+            self.title = title
+            self.placeholder = placeholder
+            self.isSecureTextEntry = isSecureTextEntry
+            self.textContentType = textContentType
+        }
+    }
+    
+    public var value: String? {
+        return self.textField.text
+    }
+    
+    private lazy var label: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.textColor = theme.primaryTextColor
+        label.font = UIFont.preferredFont(forTextStyle: .subheadline, weight: .semibold)
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        label.setContentHuggingPriority(.required, for: .vertical)
+        return label
+    }()
+    
+    private lazy var textField: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.font = UIFont.preferredFont(forTextStyle: .body)
+        textField.adjustsFontForContentSizeCategory = true
+        textField.autocapitalizationType = .none
+        textField.autocorrectionType = .no
+        textField.backgroundColor = .clear
+        textField.clearButtonMode = .never
+        textField.delegate = self
+        return textField
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 5
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
+        return stackView
+    }()
+    
+    public var theme: Theme = .current
+    
+    public init(theme: Theme) {
+        self.theme = theme
+        super.init(frame: .zero)
+        self.stackView.addArrangedSubview(self.label)
+        self.stackView.addArrangedSubview(self.textField)
+        self.addSubview(self.stackView)
+        self.configureConstraints()
+        self.textField.addTarget(self, action: #selector(self.textFieldValueDidChange(textField:)), for: .editingChanged)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.becomeFirstResponder))
+        self.addGestureRecognizer(tapGesture)
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureConstraints() {
+        NSLayoutConstraint.activate([
+            self.stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
+            self.stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
+            self.stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
+            self.stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0)
+        ])
+    }
+    
+    public func configure(config: Config){
+        self.label.text = config.title
+        self.textField.placeholder = config.placeholder
+        self.textField.isSecureTextEntry = config.isSecureTextEntry
+        self.textField.textContentType = config.textContentType
+    }
+    
+    public override func becomeFirstResponder() -> Bool {
+        return self.textField.becomeFirstResponder()
+    }
+    
+    public override func resignFirstResponder() -> Bool {
+        return self.textField.resignFirstResponder()
+    }
+    
+    @IBAction func textFieldValueDidChange(textField : UITextField){
+        self.delegate?.valueDidChange(textField: self)
+    }
+
+}
+
+extension MWROPCTextField : UITextFieldDelegate {
+    
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if let delegate = self.delegate{
+            delegate.onReturnTapped(textField: self)
+        }else{
+            self.textField.resignFirstResponder()
+        }
+        return true
+    }
+    
+}


### PR DESCRIPTION
[MW-1719]

Rebuild the "ROPC" controller (which has native username and password fields).
0.5) Improve parsing to allow nil refresh_token
1) Use the UI from the Core Forms plugin shown here
https://www.app-rail.io/apps/login changing the button text to "Continue"
2) In additional allow optional text and image
3) After the user taps "Submit" make the network query to login before the modal controller is dismissed

**Steps to test:**

* Test that the UI looks like the forms plugin
* Test that login is successful
* Test that login error is displayed in the screen
* Test that loading appears in the screen
* Test that controller only disappears once login request come back successful
* Test that submit button is called "Continue"
* Test that optional text and image can be added
* Test the nil refresh token case (not sure how yet, I have asked Matt)
* Check that there is not dependency on Research Kit or Forms plugin

[This](https://www.app-rail.io/apps/background-location-homesafe-app) is the app I have been using to test. You can create an account and test scan QR Code each time to do a new login.

**Expected result:**

As described above

Before and after screenshots

![Screenshot 2021-11-08 at 09 46 57](https://user-images.githubusercontent.com/1862078/140720028-ca39dbd5-2993-4344-b063-a46263019b0c.png)

![Screenshot 2021-11-08 at 09 47 14](https://user-images.githubusercontent.com/1862078/140720040-98ca3805-8562-436b-873c-25af46394e2f.png)







[MW-1719]: https://futureworkshops.atlassian.net/browse/MW-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ