### PR TITLE
added and using optional image and text for ROPC Login item instead o…

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.0.29'
+    s.version               = '0.0.30'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/AuthStepItem.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/AuthStepItem.swift
@@ -29,8 +29,10 @@ class AuthStepItem: Codable {
     let appleFullNameScope: Bool?
     let appleEmailScope: Bool?
     let appleAccessTokenURL: String?
+    let imageURL: String?
+    let text: String?
     
-    init(type: ItemType, buttonTitle: String, oAuth2Url: String?, oAuth2ClientId: String?, oAuth2ClientSecret: String?, oAuth2Scope: String?, oAuth2RedirectScheme: String?, oAuth2TokenUrl: String?, modalWorkflowId: String?, appleFullNameScope: Bool?, appleEmailScope: Bool?, appleAccessTokenURL: String?) {
+    init(type: ItemType, buttonTitle: String, oAuth2Url: String?, oAuth2ClientId: String?, oAuth2ClientSecret: String?, oAuth2Scope: String?, oAuth2RedirectScheme: String?, oAuth2TokenUrl: String?, modalWorkflowId: String?, appleFullNameScope: Bool?, appleEmailScope: Bool?, appleAccessTokenURL: String?, imageURL: String?, text: String?) {
 
         self.type = type
         self.buttonTitle = buttonTitle
@@ -44,6 +46,8 @@ class AuthStepItem: Codable {
         self.appleFullNameScope = appleFullNameScope
         self.appleEmailScope = appleEmailScope
         self.appleAccessTokenURL = appleAccessTokenURL
+        self.imageURL = imageURL
+        self.text = text
     }
 }
 
@@ -59,6 +63,8 @@ struct OAuthROPCConfig {
     let oAuth2TokenUrl: String
     let oAuth2ClientId: String
     let oAuth2ClientSecret: String?
+    let imageURL: String?
+    let text: String?
 }
 
 enum AuthStepItemRepresentation {
@@ -92,7 +98,7 @@ extension AuthStepItem {
             guard let oAuth2TokenUrl = self.oAuth2TokenUrl, let oAuth2ClientId = self.oAuth2ClientId else {
                 throw ParseError.invalidStepData(cause: "Missing required OAuth2 parameters")
             }
-            return .oauthRopc(buttonTitle: self.buttonTitle, config: OAuthROPCConfig(oAuth2TokenUrl: oAuth2TokenUrl, oAuth2ClientId: oAuth2ClientId, oAuth2ClientSecret: self.oAuth2ClientSecret))
+            return .oauthRopc(buttonTitle: self.buttonTitle, config: OAuthROPCConfig(oAuth2TokenUrl: oAuth2TokenUrl, oAuth2ClientId: oAuth2ClientId, oAuth2ClientSecret: self.oAuth2ClientSecret, imageURL: self.imageURL, text: self.text))
         case .twitter:
             return .twitter(buttonTitle: self.buttonTitle)
         case .modalWorkflow:

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -193,6 +193,9 @@ extension MWAppAuthStep: BuildableStep {
             let appleEmailScope = content["appleEmailScope"] as? Bool
             let appleAccessTokenURL = content["appleAccessTokenURL"] as? String
             
+            let itemImageURL = content["imageURL"] as? String
+            let itemText = content["text"] as? String
+            
             let item = AuthStepItem(
                 type: type,
                 buttonTitle: buttonTitle,
@@ -205,7 +208,9 @@ extension MWAppAuthStep: BuildableStep {
                 modalWorkflowId: modalWorkflowId,
                 appleFullNameScope: appleFullNameScope,
                 appleEmailScope: appleEmailScope,
-                appleAccessTokenURL: appleAccessTokenURL
+                appleAccessTokenURL: appleAccessTokenURL,
+                imageURL: itemImageURL,
+                text: itemText
             )
             
             _ = try item.respresentation() // confirm valid representation

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -32,8 +32,8 @@ extension MWAppAuthStepViewController {
         
         let step = ROPCStep(identifier: kFormStepIdentifier,
                             title: title,
-                            text: self.appAuthStep.text,
-                            imageURL: self.appAuthStep.imageURL,
+                            text: config.text,
+                            imageURL: config.imageURL,
                             services: self.appAuthStep.services,
                             session: self.appAuthStep.session.copyForChild(),
                             submitBlock: { [weak self] (loginViewController, credentials) in


### PR DESCRIPTION
…f MWAppAuthStep

[MW-1719]

I added optional image and text to the ROPC Login task of Login plugin. These are hidden for other items. And I changed the new ROPC Login view controller to use those instead of the ones defined for the MWAuthStep which are used in previous screen.

**Steps to test:**

* Add optional image and text ROPC Login item

**Expected result:**

Image and text should display above login form and be different from MWAuthStep image and text

![Screenshot 2021-11-16 at 15 50 08](https://user-images.githubusercontent.com/1862078/142018785-d12e7958-b575-487c-a6d7-2863852dd09d.png)



[MW-1719]: https://futureworkshops.atlassian.net/browse/MW-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ