### PR TITLE
Task/loading button

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.0.31'
+    s.version               = '0.0.32'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -50,7 +50,6 @@ final class MWROPCLoginViewController: MWContentStepViewController {
     private var scrollView: UIScrollView!
     private var contentStackView: UIStackView!
     private var imageView: UIImageView!
-    private lazy var progressIndicator = ProgressIndicator()
     
     private lazy var bodyLabel: StepBodyLabel = {
         let bodyLabel = StepBodyLabel()
@@ -292,12 +291,15 @@ final class MWROPCLoginViewController: MWContentStepViewController {
     // MARK: Loading
     
     public func showLoading() {
-        self.progressIndicator.showActivityIndicatory(on: self.navigationController?.view ?? self.view)
-        self.loginButton.isEnabled = false
+        self.usernameField.isEnabled = false
+        self.passwordField.isEnabled = false
+        self.loginButton.startLoading()
     }
 
     public func hideLoading() {
-        self.progressIndicator.hideActivityIndicator()
+        self.loginButton.stopLoading()
+        self.usernameField.isEnabled = true
+        self.passwordField.isEnabled = true
         self.loginButton.isEnabled = self.isValid
     }
     

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCTextField.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCTextField.swift
@@ -40,6 +40,15 @@ public class MWROPCTextField: UIView {
         return self.textField.text
     }
     
+    public var isEnabled : Bool {
+        get {
+            return self.textField.isEnabled
+        }
+        set {
+            self.textField.isEnabled = newValue
+        }
+    }
+    
     private lazy var label: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/UIButton+Loading.swift
+++ b/UIButton+Loading.swift
@@ -1,0 +1,53 @@
+//
+//  UIButton+Loading.swift
+//  MWAppAuthPlugin
+//
+//  Created by Julien Hebert on 09/12/2021.
+//
+
+import UIKit
+
+private let ButtonActivityIndicatorTag = 654645
+
+private class UIActivityIndicatorViewWithStorage : UIActivityIndicatorView {
+    var buttonTitle: String?
+}
+
+extension UIButton {
+    
+    func startLoading() {
+        
+        guard self.viewWithTag(ButtonActivityIndicatorTag) == nil else {return}
+        
+        self.isUserInteractionEnabled = false
+        
+        let activityIndicatorView = UIActivityIndicatorViewWithStorage()
+        activityIndicatorView.style = .white
+        activityIndicatorView.hidesWhenStopped = true
+        activityIndicatorView.color = self.titleColor(for: .normal)
+        activityIndicatorView.tag = ButtonActivityIndicatorTag
+        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicatorView.buttonTitle = self.title(for: .normal)
+        self.addSubview(activityIndicatorView)
+        
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal, toItem: activityIndicatorView, attribute: NSLayoutConstraint.Attribute.centerX, multiplier: 1.0, constant: 0.0))
+        self.addConstraint(NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal, toItem: activityIndicatorView, attribute: NSLayoutConstraint.Attribute.centerY, multiplier: 1.0, constant: 0.0))
+        
+        self.setTitle("", for: .normal)
+        
+        activityIndicatorView.startAnimating()
+        
+    }
+    
+    func stopLoading() {
+        
+        self.isUserInteractionEnabled = true
+        
+        if let activityIndicatorView = self.viewWithTag(ButtonActivityIndicatorTag) as? UIActivityIndicatorViewWithStorage {
+            self.setTitle(activityIndicatorView.buttonTitle, for: .normal)
+            activityIndicatorView.stopAnimating()
+            activityIndicatorView.removeFromSuperview()
+        }
+        
+    }
+}


### PR DESCRIPTION
[MW-1966]

Changed the loading style for ROPC Login from Progress Hud to Activity Indicator on top of button. I implemented it this way to avoid changing the core. The other cleanest option I think would be to add the capability to CustomButton.

![IMG_8586](https://user-images.githubusercontent.com/1862078/145417168-1c9d6078-7fa1-4e3c-8a5a-5ce6dbe33d6a.PNG)

![IMG_AB7002EA89A6-1](https://user-images.githubusercontent.com/1862078/145417200-cb1ee948-1f22-48c4-8645-15215ec16fa9.jpeg)




[MW-1966]: https://futureworkshops.atlassian.net/browse/MW-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ