### PR TITLE
show custom alert in case of 401 error

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.0.33'
+    s.version               = '0.0.34'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -22,6 +22,9 @@ enum L10n {
         static let usernameFieldTitle = "Username"
         static let passwordFieldTitle = "Password"
         static let required = "Required"
+        static let unauthorisedAlertTitle = "Unauthorised"
+        static let unauthorisedAlertMessage = "Incorrect email or password. Please try again."
+        static let unauthorisedAlertButton = "OK"
     }
     
     enum AppleLogin {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -107,7 +107,15 @@ extension MWAppAuthStepViewController {
                     }
                 })
             case .failure(let error):
-                loginViewController.show(error)
+                
+                if let urlError = error as? URLError, urlError.code.rawValue == 401 {
+                    let alert = UIAlertController(title: L10n.AppAuth.unauthorisedAlertTitle, message: L10n.AppAuth.unauthorisedAlertMessage, preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: L10n.AppAuth.unauthorisedAlertButton, style: .default, handler: nil))
+                    loginViewController.present(alert, animated: true, completion: nil)
+                } else{
+                    loginViewController.show(error)
+                }
+                
             }
         }
     }


### PR DESCRIPTION
[MW-2042]

Display a custom error message in response to 401 error.

I kept the implementation contained within the plugin as I did not want to change the core implementation for error messages in alert as it could affect other places.

[MW-2042]: https://futureworkshops.atlassian.net/browse/MW-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ