### PR TITLE
Handle 400 invalid_grant error

### DIFF
--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+AppAuth.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+AppAuth.swift
@@ -70,6 +70,9 @@ extension MWAppAuthStepViewController {
                 case .failure(let error):
                     if let authError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? ASWebAuthenticationSessionError, authError.code == .canceledLogin {
                         // if cancel, do nothing
+                    } else if error.isAuthenticationError {
+                        // We are handling all possible authentication errors (401, 400 invalid_grant, etc) as authentication required
+                        self?.show(URLError(URLError.Code.userAuthenticationRequired))
                     } else {
                         self?.show(error)
                     }

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -150,7 +150,7 @@ extension MWAppAuthStepViewController {
                 })
             case .failure(let error):
                 
-                if let urlError = error as? URLError, urlError.code.rawValue == 401 {
+                if error.isAuthenticationError {
                     let alert = UIAlertController(title: L10n.AppAuth.unauthorisedAlertTitle, message: L10n.AppAuth.unauthorisedAlertMessage, preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: L10n.AppAuth.unauthorisedAlertButton, style: .default, handler: nil))
                     loginViewController.present(alert, animated: true, completion: nil)

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/Model/Error+Login.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/Model/Error+Login.swift
@@ -1,0 +1,18 @@
+//
+//  Error+Login.swift
+//  AppAuth
+//
+//  Created by Igor Ferreira on 23/02/2022.
+//
+
+import Foundation
+
+extension Error {
+    var isAuthenticationError: Bool {
+        guard let urlError = self as? URLError else { return false }
+        switch(urlError.code.rawValue) {
+        case 400, 401: return true
+        default: return false
+        }
+    }
+}


### PR DESCRIPTION
### Task

[[iOS] [Android] [AppRailAirtable] [Login Plugin] Show unauthorised error for 400 response](https://3.basecamp.com/5245563/buckets/26145695/todos/4632331790)

### Goal

By [OAuth 2.0 error definition](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2), an invalid password/username on login request should return a 400 with `invalid_grant` as response reason.

### Implementation

Exclusively at login plugin, if the response for an authorization returns 400, it is shown with the same behaviour of 401.