### PR TITLE
Can now shake-to-clear from ROPC login modal

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.2.1'
+    s.version               = '0.2.2'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -85,6 +85,8 @@ extension MWAppAuthStepViewController {
                 }
             )
         )
+        // grab the delegate from our stepNavigationController so we can forward shake events
+        vc.stepNavigationViewControllerDelegate = (self.navigationController as? StepNavigationViewController)?.stepNavigationViewControllerDelegate
 
         let isPad = UIDevice.current.userInterfaceIdiom == .pad
         vc.modalPresentationStyle = isPad ? .formSheet : .fullScreen


### PR DESCRIPTION
Waiting for wire task to be created/prioritised, but this was a quick fix to issue Oliver raised.