### PR TITLE
Fixed OAuthSessionResponseInterceptor

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.2.2'
+    s.version               = '0.2.3'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS


### PR DESCRIPTION
### Summary

The interception was failing as it was attempted to cast the response to `Data`, and not:
```Swift
typealias UploadResponse = (statusCode: Int, data: Data?)
```

### Implementation

I've updated the casting/modification to handle the response as either `Data` or `UploadResponse`. If we suspect that we may need to handle more types of responses in future, we could consider adding a generic solution.