### PR TITLE
Animated transition for remotely loaded images

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.2.4'
+    s.version               = '0.2.5'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -120,7 +120,7 @@ class MWAppAuthStep: MWStep, TableStep {
     func configureTableCell(_ cell: UITableViewCell, indexPath: IndexPath, tableView: UITableView) {
         if indexPath.section == 0 {
             guard let imageCell = cell as? MWImageTableViewCell else { preconditionFailure() }
-            imageCell.backgroundImage = nil
+            imageCell.configure(backgroundImage: nil, animated: false)
             return
         }
         

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -81,7 +81,7 @@ class MWAppAuthStepViewController: MWTableStepViewController<MWAppAuthStep>, Pre
             return
         }
         let cancellable = self.appAuthStep.services.imageLoadingService.load(image: imageURL, session: self.appAuthStep.session) { [weak self] result in
-            self?.update(image: result.image, of: cell)
+            self?.update(image: result.image, of: cell, animated: result.wasLoadedRemotely)
             self?.ongoingImageLoads.removeValue(forKey: indexPath)
         }
         self.ongoingImageLoads[indexPath] = cancellable // will be nil if image was returned from cache

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -80,8 +80,8 @@ class MWAppAuthStepViewController: MWTableStepViewController<MWAppAuthStep>, Pre
             self.update(image: nil, of: cell, animated: false)
             return
         }
-        let cancellable = self.appAuthStep.services.imageLoadingService.fromCacheElseAsyncLoad(image: imageURL, session: self.appAuthStep.session) { [weak self] image, fromCache in
-            self?.update(image: image, of: cell, animated: !fromCache)
+        let cancellable = self.appAuthStep.services.imageLoadingService.load(image: imageURL, session: self.appAuthStep.session) { [weak self] result in
+            self?.update(image: result.image, of: cell)
             self?.ongoingImageLoads.removeValue(forKey: indexPath)
         }
         self.ongoingImageLoads[indexPath] = cancellable // will be nil if image was returned from cache

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -77,19 +77,19 @@ class MWAppAuthStepViewController: MWTableStepViewController<MWAppAuthStep>, Pre
     
     private func loadImage(for cell: UITableViewCell, at indexPath: IndexPath) {
         guard let imageURL = self.appAuthStep.imageURL else {
-            self.update(image: nil, of: cell)
+            self.update(image: nil, of: cell, animated: false)
             return
         }
         let cancellable = self.appAuthStep.services.imageLoadingService.asyncLoad(image: imageURL, session: self.appAuthStep.session) { [weak self] image in
-            self?.update(image: image, of: cell)
+            self?.update(image: image, of: cell, animated: true)
             self?.ongoingImageLoads.removeValue(forKey: indexPath)
         }
         self.ongoingImageLoads[indexPath] = cancellable
     }
     
-    private func update(image: UIImage?, of cell: UITableViewCell) {
+    private func update(image: UIImage?, of cell: UITableViewCell, animated: Bool) {
         guard let cell = cell as? MWImageTableViewCell else { return }
-        cell.backgroundImage = image
+        cell.configure(backgroundImage: image, animated: animated)
         cell.setNeedsLayout()
     }
     

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController.swift
@@ -80,11 +80,11 @@ class MWAppAuthStepViewController: MWTableStepViewController<MWAppAuthStep>, Pre
             self.update(image: nil, of: cell, animated: false)
             return
         }
-        let cancellable = self.appAuthStep.services.imageLoadingService.asyncLoad(image: imageURL, session: self.appAuthStep.session) { [weak self] image in
-            self?.update(image: image, of: cell, animated: true)
+        let cancellable = self.appAuthStep.services.imageLoadingService.fromCacheElseAsyncLoad(image: imageURL, session: self.appAuthStep.session) { [weak self] image, fromCache in
+            self?.update(image: image, of: cell, animated: !fromCache)
             self?.ongoingImageLoads.removeValue(forKey: indexPath)
         }
-        self.ongoingImageLoads[indexPath] = cancellable
+        self.ongoingImageLoads[indexPath] = cancellable // will be nil if image was returned from cache
     }
     
     private func update(image: UIImage?, of cell: UITableViewCell, animated: Bool) {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -151,7 +151,7 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         
         if image == nil, let imageUrl = imageUrl {
             self.imageLoad = self.ropcStep.services.imageLoadingService.load(image: imageUrl, session: self.ropcStep.session) { [weak self] result in
-                self?.updateImage(result.image, showPlaceholder: false)
+                self?.updateImage(result.image, showPlaceholder: false, animated: result.wasLoadedRemotely)
                 self?.imageLoad = nil
             }
             if self.imageView.image == nil {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -150,26 +150,26 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         self.imageView.translatesAutoresizingMaskIntoConstraints = false
         
         if image == nil, let imageUrl = imageUrl {
-            self.imageLoad = self.ropcStep.services.imageLoadingService.asyncLoad(image: imageUrl, session: self.ropcStep.session) { [weak self] in
-                self?.updateImage($0, showPlaceholder: false)
+            self.imageLoad = self.ropcStep.services.imageLoadingService.fromCacheElseAsyncLoad(image: imageUrl, session: self.ropcStep.session) { [weak self] image, fromCache in
+                self?.updateImage(image, showPlaceholder: false, animated: !fromCache)
                 self?.imageLoad = nil
             }
             if self.imageView.image == nil {
-                self.updateImage(nil, showPlaceholder: true)
+                self.updateImage(nil, showPlaceholder: true, animated: false)
             }
         } else {
-            self.updateImage(image, showPlaceholder: false)
+            self.updateImage(image, showPlaceholder: false, animated: false)
         }
     }
     
-    private func updateImage(_ image: UIImage?, showPlaceholder: Bool) {
+    private func updateImage(_ image: UIImage?, showPlaceholder: Bool, animated: Bool) {
         if image == nil, showPlaceholder {
             let imageConfig = UIImage.SymbolConfiguration(textStyle: .largeTitle)
             let image = UIImage(systemName: "photo", withConfiguration: imageConfig)
-            self.imageView.image = image
+            self.imageView.transition(to: image, animated: animated)
             self.imageView.contentMode = .center
         } else {
-            self.imageView.image = image
+            self.imageView.transition(to: image, animated: animated)
             self.imageView.contentMode = .scaleAspectFill
         }
         let heightMultiplier: CGFloat = self.imageView.image == nil ? 0.0 : 0.3

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -150,8 +150,8 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         self.imageView.translatesAutoresizingMaskIntoConstraints = false
         
         if image == nil, let imageUrl = imageUrl {
-            self.imageLoad = self.ropcStep.services.imageLoadingService.fromCacheElseAsyncLoad(image: imageUrl, session: self.ropcStep.session) { [weak self] image, fromCache in
-                self?.updateImage(image, showPlaceholder: false, animated: !fromCache)
+            self.imageLoad = self.ropcStep.services.imageLoadingService.load(image: imageUrl, session: self.ropcStep.session) { [weak self] result in
+                self?.updateImage(result.image, showPlaceholder: false)
                 self?.imageLoad = nil
             }
             if self.imageView.image == nil {


### PR DESCRIPTION
### Task

[[iOS] [Android] Image loading states](https://3.basecamp.com/5245563/buckets/26145695/todos/4825281143/edit?replace=true)

### Summary

Adding animated transition to loaded image.

### Implementation

Updated to use `ImageLoadingService` `load(image:session:completion:)` and `UIImageView` `transition(to:animated:completion:)` to update the image. 
