### PR TITLE
Update init labels and types to comply with changes in the Core for analytics

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.2.5'
+    s.version               = '0.2.6'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
 	s.default_subspecs      = 'Core'
 	
     s.subspec 'Core' do |cs|
-        cs.dependency            'MobileWorkflow', '~> 2.0.3'
-	cs.dependency            'AppAuth', '~> 1.4.0'
-        cs.source_files          = 'MWAppAuthPlugin/MWAppAuthPlugin/**/*.swift'
+      cs.dependency            'MobileWorkflow', '~> 2.0.9'
+      cs.dependency            'AppAuth', '~> 1.4.0'
+      cs.source_files          = 'MWAppAuthPlugin/MWAppAuthPlugin/**/*.swift'
     end
 end

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -19,7 +19,7 @@ fileprivate class ROPCFormTaskViewController: StepNavigationViewController {
         initialStep: Step,
         session: Session,
         theme: Theme = .current,
-        analytics: Analytics? = nil,
+        services: StepServices? = nil,
         outputDirectory: URL?,
         presentation: Presentation?
     ) {
@@ -29,7 +29,7 @@ fileprivate class ROPCFormTaskViewController: StepNavigationViewController {
             initialStep: initialStep,
             session: session,
             theme: theme,
-            analytics: analytics,
+            services: services,
             outputDirectory: outputDirectory,
             presentation: presentation
         )
@@ -65,7 +65,7 @@ extension MWAppAuthStepViewController {
             initialStep: step,
             session: childSession,
             theme: self.mwStep.theme,
-            analytics: nil,
+            services: self.appAuthStep.services,
             outputDirectory: self.outputDirectory,
             presentation: .init(
                 context: .init(


### PR DESCRIPTION
### Task

[[iOS] [Android] [Rails] Google Analytics Service](https://3.basecamp.com/5245563/buckets/26145695/todos/4921049696)

### Feature/Issue

The core had changes in the constructor of `StepNavigationViewController` that impacted this plugin and the `ROPCFormTaskViewController` can now trigger analytics events.

### Implementation

The `services` are now passed into the `StepNavigationViewController` and these same services are able to log screen view and other analytics events. The necessary init methods had the labels renamed to comply with the core and use the new feature in the ROPC flow.