### PR TITLE
Removed hardcoded margins and better adopting of Theme

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.2.9'
+    s.version               = '0.2.10'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStep.swift
@@ -142,24 +142,27 @@ class MWAppAuthStep: MWStep, TableStep {
             guard let buttonCell = cell as? MWButtonTableViewCell else {
                 preconditionFailure()
             }
-            buttonCell.configureButton(label: buttonTitle, style: .primary)
+            buttonCell.configureButton(label: buttonTitle, style: .primary, theme: self.theme)
         case .oauthRopc(let buttonTitle, _):
             guard let buttonCell = cell as? MWButtonTableViewCell else {
                 preconditionFailure()
             }
-            buttonCell.configureButton(label: buttonTitle, style: .primary)
+            buttonCell.configureButton(label: buttonTitle, style: .primary, theme: self.theme)
         case .twitter(let buttonTitle):
             guard let buttonCell = cell as? MWButtonTableViewCell else {
                 preconditionFailure()
             }
-            buttonCell.configureButton(label: buttonTitle, style: .primary)
+            buttonCell.configureButton(label: buttonTitle, style: .primary, theme: self.theme)
         case .modalLink(let buttonTitle, _):
             guard let buttonCell = cell as? MWButtonTableViewCell else {
                 preconditionFailure()
             }
-            buttonCell.configureButton(label: buttonTitle, style: .outline)
+            buttonCell.configureButton(label: buttonTitle, style: .outline, theme: self.theme)
         case .apple:
-            break // no configuration required
+            guard let buttonCell = cell as? SignInWithAppleButtonTableViewCell else {
+                preconditionFailure()
+            }
+            buttonCell.theme = self.theme
         }
     }
 }

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -48,6 +48,8 @@ final class MWROPCLoginViewController: MWContentStepViewController {
     
     public override var titleMode: StepViewControllerTitleMode { .largeTitle }
     private var scrollView: UIScrollView!
+    private var separatorLineStackView: UIStackView!
+    private var containerStackView: UIStackView!
     private var contentStackView: UIStackView!
     private var imageView: UIImageView!
     
@@ -142,6 +144,11 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         self.configureStyle()
     }
+    
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        self.configureMargins()
+    }
 
     private func configureImageView(imageUrl: String?, image: UIImage?) {
         self.imageView = self.imageView ?? UIImageView()
@@ -180,14 +187,19 @@ final class MWROPCLoginViewController: MWContentStepViewController {
     
     private func configureStackView() {
         
-        let separatorLineStackView = UIStackView( arrangedSubviews: [self.separatorLine])
-        separatorLineStackView.isLayoutMarginsRelativeArrangement = true
-        separatorLineStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0)
+        self.separatorLineStackView = UIStackView( arrangedSubviews: [self.separatorLine])
+        self.separatorLineStackView.isLayoutMarginsRelativeArrangement = true
+        self.separatorLineStackView.directionalLayoutMargins = .init(
+            top: 0,
+            leading: MWROPCTextField.ContentMargins.leading,
+            bottom: 0,
+            trailing: 0
+        )
         
         let fieldsStackView = UIStackView(
             arrangedSubviews: [
                 self.usernameField,
-                separatorLineStackView,
+                self.separatorLineStackView,
                 self.passwordField
             ]
         )
@@ -200,20 +212,19 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         fieldsStackView.spacing = 0
         
         // container to ensure top alignment
-        let containerStackView = UIStackView(
+        self.containerStackView = UIStackView(
             arrangedSubviews: [self.bodyLabel, fieldsStackView, self.loginButton]
         )
-        containerStackView.translatesAutoresizingMaskIntoConstraints = false
-        containerStackView.axis = .vertical
-        containerStackView.alignment = .fill
-        containerStackView.spacing = 20
-        containerStackView.isLayoutMarginsRelativeArrangement = true
-        containerStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+        self.containerStackView.translatesAutoresizingMaskIntoConstraints = false
+        self.containerStackView.axis = .vertical
+        self.containerStackView.alignment = .fill
+        self.containerStackView.spacing = 20
+        self.containerStackView.isLayoutMarginsRelativeArrangement = true
         
         let contentStackView = UIStackView(
             arrangedSubviews: [
                 self.imageView,
-                containerStackView
+                self.containerStackView
             ]
         )
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -233,6 +244,17 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         self.scrollView?.removeFromSuperview()
         self.scrollView = scrollView
         self.contentView.addSubview(scrollView)
+        
+        self.configureMargins()
+    }
+    
+    private func configureMargins() {
+        self.containerStackView.directionalLayoutMargins = .init(
+            top: 0,
+            leading: self.view.directionalLayoutMargins.leading,
+            bottom: 0,
+            trailing: self.view.directionalLayoutMargins.trailing
+        )
     }
     
     private func configureConstraints() {

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCTextField.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCTextField.swift
@@ -14,6 +14,8 @@ public protocol MWROPCTextFieldDelegate: AnyObject {
 }
 
 public class MWROPCTextField: UIView {
+
+    static var ContentMargins = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
     
     public weak var delegate : MWROPCTextFieldDelegate?
     
@@ -80,7 +82,7 @@ public class MWROPCTextField: UIView {
         stackView.alignment = .fill
         stackView.spacing = 5
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
+        stackView.directionalLayoutMargins = Self.ContentMargins
         return stackView
     }()
     

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/SignInWithAppleButtonTableViewCell.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/SignInWithAppleButtonTableViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import AuthenticationServices
+import MobileWorkflowCore
 
 protocol SignInWithAppleButtonTableViewCellDelegate: AnyObject {
     func appleCell(_ cell: SignInWithAppleButtonTableViewCell, didTapButton button: UIButton)
@@ -17,6 +18,12 @@ final class SignInWithAppleButtonTableViewCell: UITableViewCell {
     private var loginButton: ASAuthorizationAppleIDButton?
     weak var delegate: SignInWithAppleButtonTableViewCellDelegate?
     
+    public var theme: Theme = .current {
+        didSet {
+            self.configureCell()
+        }
+    }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.configureCell()
@@ -26,39 +33,35 @@ final class SignInWithAppleButtonTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func configureCell() {
-        
-        self.backgroundColor = .secondarySystemBackground
-        self.contentView.backgroundColor = .secondarySystemBackground
-        
-        self.setupLoginButton()
-        self.setupConstraints()
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        self.configureCell()
     }
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        if previousTraitCollection?.userInterfaceStyle != self.traitCollection.userInterfaceStyle {
-            self.configureCell()
-        }
+    private func configureCell() {
+        
+        self.backgroundColor = self.theme.primaryBackgroundColor
+        self.contentView.backgroundColor = self.theme.primaryBackgroundColor
+        
+        self.setupLoginButton()
     }
     
     private func setupLoginButton() {
-        self.loginButton?.removeFromSuperview()
+        self.loginButton?.removeFromSuperview() // removes previous constraints
+        
         let loginButton = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: self.traitCollection.userInterfaceStyle == .dark ? .white : .black)
-        loginButton.cornerRadius = 14
+        loginButton.cornerRadius = self.theme.buttonCornerRadius
         loginButton.addTarget(self, action: #selector(self.didTapSignIn(_:)), for: .touchUpInside)
         loginButton.translatesAutoresizingMaskIntoConstraints = false
         self.loginButton = loginButton
         self.contentView.addSubview(loginButton)
-    }
-    
-    private func setupConstraints() {
-        guard let loginButton = self.loginButton else { preconditionFailure() }
+        
         NSLayoutConstraint.activate([
-            loginButton.topAnchor.constraint(equalTo: self.contentView.safeAreaLayoutGuide.topAnchor, constant: 16),
-            loginButton.leftAnchor.constraint(equalTo: self.contentView.safeAreaLayoutGuide.leftAnchor, constant: 16),
-            loginButton.rightAnchor.constraint(equalTo: self.contentView.safeAreaLayoutGuide.rightAnchor, constant: -16),
-            loginButton.bottomAnchor.constraint(lessThanOrEqualTo: self.contentView.safeAreaLayoutGuide.bottomAnchor, constant: -16),
-            loginButton.heightAnchor.constraint(equalToConstant: 44)
+            loginButton.topAnchor.constraint(equalTo: self.contentView.safeAreaLayoutGuide.topAnchor, constant: 12),
+            loginButton.leftAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.leftAnchor, constant: 0),
+            loginButton.rightAnchor.constraint(equalTo: self.contentView.layoutMarginsGuide.rightAnchor, constant: 0),
+            loginButton.bottomAnchor.constraint(lessThanOrEqualTo: self.contentView.safeAreaLayoutGuide.bottomAnchor, constant: -12),
+            loginButton.heightAnchor.constraint(equalToConstant: 50)
         ])
     }
     


### PR DESCRIPTION
### Task

Related to:
[[iOS] [Background Location] Instructions fixes](https://3.basecamp.com/5245563/buckets/26145695/todos/5003653353/edit?replace=true)

### Feature/Issue

Apple adopt a standard margin of 20pts on 'Max' size iPhones, but we've been hardcoding 16pts by default.

### Implementation

Were relevant:
- Updated leading and trailing constraints to anchor to the `layoutMarginsGuide`
- Updated `directionalLayoutMargins` of stackViews to reflect those of the containing viewController

### Notes

Have also updated to adopt Theme properties in a few places were this wasn't being done.