### PR TITLE
Make interceptor public

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.3.0'
+    s.version               = '0.3.1'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/OAuthSessionResponseInterceptor.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/OAuthSessionResponseInterceptor.swift
@@ -10,17 +10,15 @@ import MobileWorkflowCore
 
 private let kOAuthSession = "oauth_session"
 
-private typealias UploadResponse = (statusCode: Int, data: Data?) // adding here until available publicly from core
-
-class OAuthSessionResponseInterceptor: AsyncTaskInterceptor {
+public class OAuthSessionResponseInterceptor: AsyncTaskInterceptor {
     
-    let credentialStore: CredentialStoreProtocol
+    private let credentialStore: CredentialStoreProtocol
     
-    init(credentialStore: CredentialStoreProtocol) {
+    public init(credentialStore: CredentialStoreProtocol) {
         self.credentialStore = credentialStore
     }
     
-    func interceptResponse<T>(_ response: T, session: ContentProvider) -> T {
+    public func interceptResponse<T>(_ response: T, session: ContentProvider) -> T {
         var data: Data?
         if let response = response as? Data {
             data = response


### PR DESCRIPTION
<!-- TITLE OF THE PR: For the title, if there is an associated task/todo/pitch, please create the PR with the task name. Example: [iOS] Empty view behaviour -->

### Task

<!-- Please, add here links to the task/pitch/todo/thread that triggered this Pull Request. Example: [[iOS] Empty view behaviour](https://3.basecamp.com/5245563/buckets/26145695/todos/4882286741) -->

Required to complete [Move Anonymous login step to Onboarding flow](https://3.basecamp.com/5245563/buckets/28222393/todos/5282321445)


### Feature/Issue

<!-- Please describe in short terms what is the scope of the feature or what is the bug that is being fixed -->

### Implementation

<!-- Please describe the general idea of what was implemented. Comments that may help your peer reviewer. Things like: architectural details, points of attention, etc. -->

Makes `OAuthSessionResponseInterceptor` `public` so it can be used by other plugins.

### Notes

<!-- If there is any test step, or consideration about the feature, please, add it here. This may include prints/videos of the feature in action. -->