### PR TITLE
[iOS] [Sign in Step] Logging in an email with "+" changes it to " "

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.3.1'
+    s.version               = '0.3.2'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWAppAuthStepViewController+ROPC.swift
@@ -110,11 +110,13 @@ extension MWAppAuthStepViewController {
         }
         
         let paramsString = params.map({ "\($0.key)=\($0.value)" }).joined(separator: "&") // url encoding
+        let allowedChars = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "=&"))
+        let escapedParamsString = paramsString.addingPercentEncoding(withAllowedCharacters: allowedChars) ?? paramsString // e.g. '+' is reserved char for postman, and if unescaped and it gets replaced with a space char
         
         let task = URLAsyncTask<ROPCResponse>.build(
             url: tokenURL,
             method: .POST,
-            body: paramsString.data(using: .utf8),
+            body: escapedParamsString.data(using: .utf8),
             session: self.appAuthStep.session,
             headers: ["Content-Type": "application/x-www-form-urlencoded"],
             parser: { try ROPCResponse.parse(data: $0) }


### PR DESCRIPTION
### Task

[[iOS] [Sign in Step] Logging in an email with "+" changes it to " "](https://3.basecamp.com/5245563/buckets/26145695/todos/5336682282/edit?replace=true)

### Feature/Issue

Plus characters sent in `x-www-form-urlencoded` bodies get replaced with a space by postman (and potentially other servers), where it is considered a reserved character: https://github.com/postmanlabs/postman-app-support/issues/8849

### Implementation

Added character escaping for any characters not belonging to:
- alphanumerics (safe to leave unescaped)
- `=` and `&` (form structure chars)