### PR TITLE
[iOS] Remove SF Symbols icon from image placeholder

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.3.2'
+    s.version               = '0.3.3'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS

--- a/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
+++ b/MWAppAuthPlugin/MWAppAuthPlugin/AppAuthStep/MWROPCLoginViewController.swift
@@ -158,28 +158,21 @@ final class MWROPCLoginViewController: MWContentStepViewController {
         if image == nil, let imageUrl = imageUrl {
             self.imageLoad = Task {
                 let result = await self.ropcStep.services.imageLoadingService.load(image: imageUrl, session: self.ropcStep.session)
-                self.updateImage(result.image, showPlaceholder: false, animated: result.wasLoadedRemotely)
+                self.updateImage(result.image, animated: result.wasLoadedRemotely)
                 self.imageLoad = nil
             }
             if self.imageView.image == nil {
-                self.updateImage(nil, showPlaceholder: true, animated: false)
+                self.updateImage(nil, animated: false)
             }
         } else {
-            self.updateImage(image, showPlaceholder: false, animated: false)
+            self.updateImage(image, animated: false)
         }
     }
     
     @MainActor
-    private func updateImage(_ image: UIImage?, showPlaceholder: Bool, animated: Bool) {
-        if image == nil, showPlaceholder {
-            let imageConfig = UIImage.SymbolConfiguration(textStyle: .largeTitle)
-            let image = UIImage(systemName: "photo", withConfiguration: imageConfig)
-            self.imageView.transition(to: image, animated: animated)
-            self.imageView.contentMode = .center
-        } else {
-            self.imageView.transition(to: image, animated: animated)
-            self.imageView.contentMode = .scaleAspectFill
-        }
+    private func updateImage(_ image: UIImage?, animated: Bool) {
+        self.imageView.transition(to: image, animated: animated)
+        self.imageView.contentMode = .scaleAspectFill
         let heightMultiplier: CGFloat = self.imageView.image == nil ? 0.0 : 0.3
         self.imageViewHeightConstraint = self.imageView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: heightMultiplier)
         


### PR DESCRIPTION
### Task

[[iOS] Remove SF Symbols icon from image placeholder](https://3.basecamp.com/5245563/buckets/26145695/todos/5911910967/edit?replace=true)

### Feature/Issue

Remove the SFSymbol 'photo' icon from the ROPC step imageView placeholder.

### Implementation

Updated the UI in to show just the placeholder background colour without the icon.