### PR TITLE
Bug: [iOS] Remove SF Symbols icon from image placeholder

### DIFF
--- a/MWAppAuthPlugin.podspec
+++ b/MWAppAuthPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWAppAuthPlugin'
-    s.version               = '0.3.3'
+    s.version               = '0.3.4'
     s.summary               = 'AppAuth plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     OAuth plugin for MobileWorkflow on iOS, based on AppAuth-iOS: https://github.com/openid/AppAuth-iOS


### PR DESCRIPTION
### Task

[[iOS] Remove SF Symbols icon from image placeholder](https://3.basecamp.com/5245563/buckets/26145695/todos/5911910967/edit?replace=true)

### Feature/Issue

Fix a regression in ROPC login step where imageView height constraint isn't set correctly when loading remote image.

### Implementation

Cleaned up `configureImageView(...)` so that the imageView is always shown when there's either an image or non-empty imageUrl provided.

### Notes

The following function in the core will be marked with `@MainActor`
```Swift
func transition(to image: UIImage?, animated: Bool, completion: ((Bool) -> Void)? = nil)
```